### PR TITLE
[WIP] Add and Fix PostgreSQL datasource type test

### DIFF
--- a/accio-base/src/main/java/io/accio/base/type/TimestampType.java
+++ b/accio-base/src/main/java/io/accio/base/type/TimestampType.java
@@ -18,9 +18,7 @@ import io.netty.buffer.ByteBuf;
 
 import javax.annotation.Nonnull;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
@@ -74,9 +72,7 @@ public class TimestampType
     @Override
     public byte[] encodeAsUTF8Text(@Nonnull Object value)
     {
-        long microSeconds = (long) value;
-        Instant instant = Instant.ofEpochSecond(microSeconds / 1000000, microSeconds % 1000000 * 1000);
-        LocalDateTime dt = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        LocalDateTime dt = (LocalDateTime) value;
         return PG_TIMESTAMP.format(dt).getBytes(UTF_8);
     }
 

--- a/accio-connector-client/src/main/java/io/accio/connector/postgres/PostgresRecordIterator.java
+++ b/accio-connector-client/src/main/java/io/accio/connector/postgres/PostgresRecordIterator.java
@@ -22,7 +22,9 @@ import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
 
 import java.sql.Blob;
+import java.sql.Date;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,6 +70,9 @@ public class PostgresRecordIterator
             else if (resultSet.getMetaData().getColumnType(i) == Types.SMALLINT) {
                 builder.add(resultSet.getShort(i));
             }
+            else if (resultSet.getMetaData().getColumnType(i) == Types.TIMESTAMP) {
+                builder.add(resultSet.getTimestamp(i).toLocalDateTime());
+            }
             else if (resultSet.getMetaData().getColumnType(i) == Types.ARRAY) {
                 List<Object> objArray = Optional.ofNullable(resultSet.getArray(i))
                         .map(array -> {
@@ -75,6 +80,12 @@ public class PostgresRecordIterator
                                 return Arrays.stream((Object[]) array.getArray()).map(obj -> {
                                     if (obj instanceof PGobject) {
                                         return getPgObjectValue((PGobject) obj);
+                                    }
+                                    if (obj instanceof Timestamp) {
+                                        return ((Timestamp) obj).toLocalDateTime();
+                                    }
+                                    if (obj instanceof Date) {
+                                        return ((Date) obj).toLocalDate();
                                     }
                                     return obj;
                                 }).collect(Collectors.toList());

--- a/accio-main/src/main/java/io/accio/main/connector/bigquery/BigQueryRecordIterator.java
+++ b/accio-main/src/main/java/io/accio/main/connector/bigquery/BigQueryRecordIterator.java
@@ -25,6 +25,7 @@ import io.accio.connector.bigquery.BigQueryType;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.Period;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Iterator;
@@ -118,7 +119,9 @@ public class BigQueryRecordIterator
             case DATETIME:
                 return convertToMicroseconds(LocalDateTime.parse(fieldValue.getStringValue()));
             case TIMESTAMP:
-                return fieldValue.getTimestampValue();
+                long microSeconds = fieldValue.getTimestampValue();
+                Instant instant = Instant.ofEpochSecond(microSeconds / 1000000, microSeconds % 1000000 * 1000);
+                return LocalDateTime.ofInstant(instant, UTC);
             case NUMERIC:
             case BIGNUMERIC:
                 return fieldValue.getNumericValue();

--- a/accio-main/src/main/java/io/accio/main/connector/postgres/PostgresSqlConverter.java
+++ b/accio-main/src/main/java/io/accio/main/connector/postgres/PostgresSqlConverter.java
@@ -14,29 +14,49 @@
 
 package io.accio.main.connector.postgres;
 
+import com.google.common.collect.ImmutableList;
 import io.accio.base.SessionContext;
 import io.accio.base.sql.SqlConverter;
+import io.accio.main.metadata.Metadata;
+import io.accio.main.sql.SqlRewrite;
+import io.accio.main.sql.postgres.RewriteToPostgresType;
 import io.airlift.log.Logger;
 import io.trino.sql.tree.Node;
 
 import javax.inject.Inject;
 
+import java.util.List;
+
 import static io.accio.sqlrewrite.Utils.parseSql;
 import static io.trino.sql.SqlFormatter.Dialect.POSTGRES;
 import static io.trino.sql.SqlFormatter.formatSql;
+import static java.util.Objects.requireNonNull;
 
 public class PostgresSqlConverter
         implements SqlConverter
 {
     private static final Logger LOG = Logger.get(PostgresSqlConverter.class);
+    private final Metadata metadata;
 
     @Inject
-    public PostgresSqlConverter() {}
+    public PostgresSqlConverter(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
 
     @Override
     public String convert(String sql, SessionContext sessionContext)
     {
         Node rewrittenNode = parseSql(sql);
+        List<SqlRewrite> sqlRewrites = ImmutableList.of(RewriteToPostgresType.INSTANCE);
+        LOG.info("[Input sql]: %s", sql);
+
+        for (SqlRewrite rewrite : sqlRewrites) {
+            LOG.debug("Before %s: %s", rewrite.getClass().getSimpleName(), formatSql(rewrittenNode));
+            rewrittenNode = rewrite.rewrite(rewrittenNode, metadata);
+            LOG.debug("After %s: %s", rewrite.getClass().getSimpleName(), formatSql(rewrittenNode));
+        }
+
         String dialectSql = formatSql(rewrittenNode, POSTGRES);
         LOG.info("[Dialect sql]: %s", dialectSql);
         return dialectSql;

--- a/accio-main/src/main/java/io/accio/main/sql/postgres/RewriteToPostgresType.java
+++ b/accio-main/src/main/java/io/accio/main/sql/postgres/RewriteToPostgresType.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.sql.postgres;
+
+import io.accio.main.metadata.Metadata;
+import io.accio.main.sql.SqlRewrite;
+import io.accio.sqlrewrite.BaseRewriter;
+import io.trino.sql.tree.BinaryLiteral;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.GenericDataType;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Node;
+import io.trino.sql.tree.StringLiteral;
+
+import java.util.List;
+import java.util.Optional;
+
+public class RewriteToPostgresType
+        implements SqlRewrite
+{
+    public static final RewriteToPostgresType INSTANCE = new RewriteToPostgresType();
+
+    private RewriteToPostgresType() {}
+
+    @Override
+    public Node rewrite(Node node, Metadata metadata)
+    {
+        RewriteToPostgresTypeRewriter rewriter = new RewriteToPostgresTypeRewriter();
+        return rewriter.process(node);
+    }
+
+    private static class RewriteToPostgresTypeRewriter
+            extends BaseRewriter<Void>
+    {
+        @Override
+        protected Node visitBinaryLiteral(BinaryLiteral node, Void context)
+        {
+            // SqlBase use X'[hex string]' to represent binary data, but PostgreSQL uses the following format to represent binary data: '\x[hex string]'
+            // To overcome this limitation, we convert the query to CAST('\x[hex string]' AS BYTEA).
+            return new Cast(new StringLiteral("\\x" + node.toHexString()), new GenericDataType(Optional.empty(), new Identifier("BYTEA"), List.of()));
+        }
+    }
+}

--- a/accio-tests/src/main/java/io/accio/testing/DataType.java
+++ b/accio-tests/src/main/java/io/accio/testing/DataType.java
@@ -84,7 +84,7 @@ public class DataType<T>
 
     public static DataType<Double> doubleDataType()
     {
-        return dataType("double", DoubleType.DOUBLE,
+        return dataType("float8", DoubleType.DOUBLE,
                 value -> {
                     if (Double.isFinite(value)) {
                         return value.toString();

--- a/accio-tests/src/main/java/io/accio/testing/DataType.java
+++ b/accio-tests/src/main/java/io/accio/testing/DataType.java
@@ -25,7 +25,6 @@ import io.accio.base.type.NumericType;
 import io.accio.base.type.PGType;
 import io.accio.base.type.RealType;
 import io.accio.base.type.SmallIntType;
-import io.accio.base.type.TinyIntType;
 import io.accio.base.type.VarcharType;
 
 import java.math.BigDecimal;
@@ -67,11 +66,6 @@ public class DataType<T>
     public static DataType<Short> smallintDataType()
     {
         return dataType("smallint", SmallIntType.SMALLINT);
-    }
-
-    public static DataType<Byte> tinyintDataType()
-    {
-        return dataType("tinyint", TinyIntType.TINYINT);
     }
 
     public static DataType<Float> realDataType()

--- a/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTypeTest.java
+++ b/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTypeTest.java
@@ -12,12 +12,11 @@
  * limitations under the License.
  */
 
-package io.accio.testing.bigquery;
+package io.accio.testing;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.accio.base.type.PGArray;
-import io.accio.testing.DataType;
 import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
 import org.testng.annotations.Test;
@@ -83,8 +82,8 @@ import static java.util.stream.IntStream.range;
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestWireProtocolType
-        extends AbstractWireProtocolTestWithBigQuery
+public abstract class AbstractWireProtocolTypeTest
+        extends AbstractWireProtocolTest
 {
     // BigQuery has only INT64 type. We should cast other int to int32 after got them.
     private static final List<String> TYPE_FORCED_TO_LONG = ImmutableList.of("integer", "smallint", "tinyint", "array(integer)", "array(smallint)", "array(tinyint)");

--- a/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTypeTest.java
+++ b/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTypeTest.java
@@ -54,7 +54,6 @@ import static io.accio.base.type.PGArray.JSON_ARRAY;
 import static io.accio.base.type.PGArray.NUMERIC_ARRAY;
 import static io.accio.base.type.PGArray.TIMESTAMP_ARRAY;
 import static io.accio.base.type.PGArray.VARCHAR_ARRAY;
-import static io.accio.base.type.SmallIntType.SMALLINT;
 import static io.accio.testing.DataType.bigintDataType;
 import static io.accio.testing.DataType.booleanDataType;
 import static io.accio.testing.DataType.byteaDataType;
@@ -107,7 +106,7 @@ public abstract class AbstractWireProtocolTypeTest
                 .addInput(booleanDataType(), false)
                 .addInput(bigintDataType(), 123_456_789_012L)
                 .addInput(integerDataType(), 1_234_567_890)
-                .addInput(jdbcSmallintDataType(), 32_456)
+                .addInput(smallintDataType(), (short)32_456)
                 .addInput(doubleDataType(), 123.45d)
                 .addInput(realDataType(), 123.45f)
                 .executeSuite();
@@ -356,14 +355,6 @@ public abstract class AbstractWireProtocolTypeTest
     private WireProtocolTypeTest createTypeTest()
     {
         return new WireProtocolTypeTest();
-    }
-
-    /**
-     * JDBC get pg smallint by Integer
-     */
-    private static DataType<Integer> jdbcSmallintDataType()
-    {
-        return dataType("smallint", SMALLINT, Object::toString);
     }
 
     public class WireProtocolTypeTest

--- a/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTypeTest.java
+++ b/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTypeTest.java
@@ -55,7 +55,6 @@ import static io.accio.base.type.PGArray.NUMERIC_ARRAY;
 import static io.accio.base.type.PGArray.TIMESTAMP_ARRAY;
 import static io.accio.base.type.PGArray.VARCHAR_ARRAY;
 import static io.accio.base.type.SmallIntType.SMALLINT;
-import static io.accio.base.type.TinyIntType.TINYINT;
 import static io.accio.testing.DataType.bigintDataType;
 import static io.accio.testing.DataType.booleanDataType;
 import static io.accio.testing.DataType.byteaDataType;
@@ -109,7 +108,6 @@ public abstract class AbstractWireProtocolTypeTest
                 .addInput(bigintDataType(), 123_456_789_012L)
                 .addInput(integerDataType(), 1_234_567_890)
                 .addInput(jdbcSmallintDataType(), 32_456)
-                .addInput(jdbcTinyintDataType(), 125)
                 .addInput(doubleDataType(), 123.45d)
                 .addInput(realDataType(), 123.45f)
                 .executeSuite();
@@ -366,14 +364,6 @@ public abstract class AbstractWireProtocolTypeTest
     private static DataType<Integer> jdbcSmallintDataType()
     {
         return dataType("smallint", SMALLINT, Object::toString);
-    }
-
-    /**
-     * JDBC get pg tinyint by Integer.
-     */
-    private static DataType<Integer> jdbcTinyintDataType()
-    {
-        return dataType("tinyint", TINYINT, Object::toString);
     }
 
     public class WireProtocolTypeTest

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolTypeWithBigQuery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolTypeWithBigQuery.java
@@ -17,8 +17,44 @@ package io.accio.testing.bigquery;
 import com.google.common.collect.ImmutableMap;
 import io.accio.testing.AbstractWireProtocolTypeTest;
 import io.accio.testing.TestingAccioServer;
+import jdk.jfr.Description;
 
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.function.Function;
+
+import static io.accio.base.type.PGArray.BOOL_ARRAY;
+import static io.accio.base.type.PGArray.BYTEA_ARRAY;
+import static io.accio.base.type.PGArray.CHAR_ARRAY;
+import static io.accio.base.type.PGArray.DATE_ARRAY;
+import static io.accio.base.type.PGArray.FLOAT4_ARRAY;
+import static io.accio.base.type.PGArray.FLOAT8_ARRAY;
+import static io.accio.base.type.PGArray.INT2_ARRAY;
+import static io.accio.base.type.PGArray.INT4_ARRAY;
+import static io.accio.base.type.PGArray.INT8_ARRAY;
+import static io.accio.base.type.PGArray.JSON_ARRAY;
+import static io.accio.base.type.PGArray.NUMERIC_ARRAY;
+import static io.accio.base.type.PGArray.TIMESTAMP_ARRAY;
+import static io.accio.base.type.PGArray.VARCHAR_ARRAY;
+import static io.accio.testing.DataType.bigintDataType;
+import static io.accio.testing.DataType.booleanDataType;
+import static io.accio.testing.DataType.byteaDataType;
+import static io.accio.testing.DataType.charDataType;
+import static io.accio.testing.DataType.dateDataType;
+import static io.accio.testing.DataType.decimalDataType;
+import static io.accio.testing.DataType.doubleDataType;
+import static io.accio.testing.DataType.integerDataType;
+import static io.accio.testing.DataType.jsonDataType;
+import static io.accio.testing.DataType.realDataType;
+import static io.accio.testing.DataType.smallintDataType;
+import static io.accio.testing.DataType.timestampDataType;
+import static io.accio.testing.DataType.varcharDataType;
 import static java.lang.System.getenv;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 
 public class TestWireProtocolTypeWithBigQuery
         extends AbstractWireProtocolTypeTest
@@ -51,5 +87,94 @@ public class TestWireProtocolTypeWithBigQuery
     protected String getDefaultSchema()
     {
         return "tpch_tiny";
+    }
+
+    @Override
+    @Description("BigQuery has only INT64 type, so we would get long value from it.")
+    // TODO https://github.com/Canner/accio/issues/196
+    public void testInteger()
+    {
+        createTypeTest()
+                .addInput(integerDataType(), 1_234_567_890, value -> (long) value)
+                .executeSuite();
+    }
+
+    @Override
+    @Description("BigQuery has only INT64 type, so we would get long value from it.")
+    // TODO https://github.com/Canner/accio/issues/196
+    public void testSmallint()
+    {
+        createTypeTest()
+                .addInput(smallintDataType(), (short) 32_456, value -> (long) value)
+                .executeSuite();
+    }
+
+    @Override
+    @Description("BigQuery has only FLOAT64 type, so we would get double value from it.")
+    // TODO https://github.com/Canner/accio/issues/196
+    public void testReal()
+    {
+        createTypeTest()
+                .addInput(realDataType(), 123.45f, value -> Double.valueOf(value.toString()))
+                .executeSuite();
+    }
+
+    @Override
+    @Description("BigQuery will remove trailing zeros from values.")
+    // TODO https://github.com/Canner/accio/issues/362
+    public void testDecimal()
+    {
+        Function<BigDecimal, BigDecimal> removeTrailingZeros = value -> new BigDecimal(value.stripTrailingZeros().toPlainString());
+
+        createTypeTest()
+                .addInput(decimalDataType(), new BigDecimal("0.123"))
+                .addInput(decimalDataType(3, 0), new BigDecimal("0"))
+                .addInput(decimalDataType(3, 0), new BigDecimal("193"))
+                .addInput(decimalDataType(3, 0), new BigDecimal("19"))
+                .addInput(decimalDataType(3, 0), new BigDecimal("-193"))
+                .addInput(decimalDataType(3, 1), new BigDecimal("10.0"), removeTrailingZeros)
+                .addInput(decimalDataType(3, 1), new BigDecimal("10.1"))
+                .addInput(decimalDataType(3, 1), new BigDecimal("-10.1"))
+                .addInput(decimalDataType(4, 2), new BigDecimal("2.00"), removeTrailingZeros)
+                .addInput(decimalDataType(4, 2), new BigDecimal("2.30"), removeTrailingZeros)
+                .addInput(decimalDataType(24, 2), new BigDecimal("2.00"), removeTrailingZeros)
+                .addInput(decimalDataType(24, 2), new BigDecimal("2.30"), removeTrailingZeros)
+                .addInput(decimalDataType(24, 2), new BigDecimal("123456789.30"), removeTrailingZeros)
+                .addInput(decimalDataType(24, 4), new BigDecimal("12345678901234567890.3100"), removeTrailingZeros)
+                .addInput(decimalDataType(30, 5), new BigDecimal("3141592653589793238462643.38327"))
+                .addInput(decimalDataType(30, 5), new BigDecimal("-3141592653589793238462643.38327"))
+                .addInput(decimalDataType(30, 0), new BigDecimal("9223372036854775807"))
+                .addInput(decimalDataType(38, 0), new BigDecimal("27182818284590452353602874713526624977"))
+                .addInput(decimalDataType(38, 9), new BigDecimal("27182818284590452353602874713.526624977"))
+                .addInput(decimalDataType(39, 9), new BigDecimal("271828182845904523536028747130.526624977"))
+                .addInput(decimalDataType(38, 10), new BigDecimal("2718281828459045235360287471.3526624977"))
+                .executeSuite();
+    }
+
+    @Override
+    // TODO https://github.com/Canner/accio/issues/196
+    public void testArray()
+    {
+        // basic types
+        createTypeTest()
+                .addInput(arrayDataType(booleanDataType(), BOOL_ARRAY), asList(true, false))
+                .addInput(arrayDataType(smallintDataType(), INT2_ARRAY), asList((short) 1, (short) 2), value -> asList(1L, 2L))
+                .addInput(arrayDataType(integerDataType(), INT4_ARRAY), asList(1, 2, 1_234_567_890), value -> asList(1L, 2L, 1_234_567_890L))
+                .addInput(arrayDataType(bigintDataType(), INT8_ARRAY), asList(123_456_789_012L, 1_234_567_890L))
+                .addInput(arrayDataType(realDataType(), FLOAT4_ARRAY), asList(123.45f, 1.2345f), value -> asList(123.45, 1.2345))
+                .addInput(arrayDataType(doubleDataType(), FLOAT8_ARRAY), asList(123.45d, 1.2345d))
+                .addInput(arrayDataType(decimalDataType(3, 1), NUMERIC_ARRAY), asList(new BigDecimal("1"), new BigDecimal("1.1")))
+                .addInput(arrayDataType(varcharDataType(), VARCHAR_ARRAY), asList("hello", "world"))
+                .addInput(arrayDataType(charDataType(), CHAR_ARRAY), asList("h", "w"))
+                .addInput(arrayDataType(byteaDataType(), BYTEA_ARRAY), asList("hello", "world"), value -> asList("\\x68656c6c6f", "\\x776f726c64"))
+                .addInput(arrayDataType(jsonDataType(), JSON_ARRAY), asList("{\"a\": \"apple\"}", "{\"b\": \"banana\"}"), value -> asList("{a:apple}", "{b:banana}"))
+                .addInput(arrayDataType(timestampDataType(3), TIMESTAMP_ARRAY),
+                        asList(LocalDateTime.of(2019, 1, 1, 1, 1, 1, 1_000_000),
+                                LocalDateTime.of(2019, 1, 1, 1, 1, 1, 2_000_000)),
+                        value -> value.stream().map(Timestamp::valueOf).collect(toList()))
+                .addInput(arrayDataType(dateDataType(), DATE_ARRAY), asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 2)),
+                        value -> value.stream().map(Date::valueOf).collect(toList()))
+                // TODO support interval
+                .executeSuite();
     }
 }

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolTypeWithBigQuery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolTypeWithBigQuery.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.testing.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import io.accio.testing.AbstractWireProtocolTypeTest;
+import io.accio.testing.TestingAccioServer;
+
+import static java.lang.System.getenv;
+
+public class TestWireProtocolTypeWithBigQuery
+        extends AbstractWireProtocolTypeTest
+{
+    @Override
+    protected TestingAccioServer createAccioServer()
+    {
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("bigquery.project-id", getenv("TEST_BIG_QUERY_PROJECT_ID"))
+                .put("bigquery.location", "asia-east1")
+                .put("bigquery.credentials-key", getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
+                .put("accio.datasource.type", "bigquery");
+
+        if (getAccioMDLPath().isPresent()) {
+            properties.put("accio.file", getAccioMDLPath().get());
+        }
+
+        return TestingAccioServer.builder()
+                .setRequiredConfigs(properties.build())
+                .build();
+    }
+
+    @Override
+    protected String getDefaultCatalog()
+    {
+        return "canner-cml";
+    }
+
+    @Override
+    protected String getDefaultSchema()
+    {
+        return "tpch_tiny";
+    }
+}

--- a/accio-tests/src/test/java/io/accio/testing/postgres/AbstractWireProtocolTestWithPostgres.java
+++ b/accio-tests/src/test/java/io/accio/testing/postgres/AbstractWireProtocolTestWithPostgres.java
@@ -19,7 +19,7 @@ import io.accio.testing.AbstractWireProtocolTest;
 import io.accio.testing.TestingAccioServer;
 import io.accio.testing.TestingPostgreSqlServer;
 
-public class AbstractWireProtocolTestWithPostgres
+public abstract class AbstractWireProtocolTestWithPostgres
         extends AbstractWireProtocolTest
 {
     private TestingPostgreSqlServer testingPostgreSqlServer;

--- a/accio-tests/src/test/java/io/accio/testing/postgres/TestWireProtocolTypeWithPostgres.java
+++ b/accio-tests/src/test/java/io/accio/testing/postgres/TestWireProtocolTypeWithPostgres.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.testing.postgres;
+
+import com.google.common.collect.ImmutableMap;
+import io.accio.testing.AbstractWireProtocolTypeTest;
+import io.accio.testing.TestingAccioServer;
+import io.accio.testing.TestingPostgreSqlServer;
+
+public class TestWireProtocolTypeWithPostgres
+        extends AbstractWireProtocolTypeTest
+{
+    @Override
+    protected TestingAccioServer createAccioServer()
+    {
+        TestingPostgreSqlServer testingPostgreSqlServer = new TestingPostgreSqlServer();
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("postgres.jdbc.url", testingPostgreSqlServer.getJdbcUrl())
+                .put("postgres.user", testingPostgreSqlServer.getUser())
+                .put("postgres.password", testingPostgreSqlServer.getPassword())
+                .put("accio.datasource.type", "POSTGRES");
+
+        if (getAccioMDLPath().isPresent()) {
+            properties.put("accio.file", getAccioMDLPath().get());
+        }
+
+        return TestingAccioServer.builder()
+                .setRequiredConfigs(properties.build())
+                .build();
+    }
+
+    @Override
+    protected String getDefaultCatalog()
+    {
+        return "tpch";
+    }
+
+    @Override
+    protected String getDefaultSchema()
+    {
+        return "tpch";
+    }
+}

--- a/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -971,7 +971,7 @@ public final class ExpressionFormatter
         }
 
         StringBuilder builder = new StringBuilder();
-        if (dialect == DEFAULT || dialect == DUCKDB) {
+        if (dialect == DEFAULT || dialect == DUCKDB || dialect == POSTGRES) {
             builder.append("U&");
         }
         builder.append("'");
@@ -987,7 +987,7 @@ public final class ExpressionFormatter
                 builder.append(ch);
             }
             else {
-                if (dialect == DEFAULT || dialect == DUCKDB) {
+                if (dialect == DEFAULT || dialect == DUCKDB || dialect == POSTGRES) {
                     if (codePoint <= 0xFFFF) {
                         builder.append('\\');
                         builder.append(format("%04X", codePoint));


### PR DESCRIPTION
## Description
The mainly is to add PostgreSQL datasource type test, but also fix the following things to make type test working.

What we do,
1. Remove `tinyint` type test, because there is no `tinyint` type in PostgreSQL
2. Fix PostgreSQL connector type
    - `bytea` type
    - `timestamp` type
    - `varchar` type with `unicode`

## Other issue
We can improve the type test by modify expected result. https://github.com/Canner/accio/issues/363