### PR TITLE
Add test with secrets when using pr in forked projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,6 @@ jobs:
       - name: build
         run: |
           ./mvnw clean install -B -DskipTests
-      - name: tests
-        env:
-          TEST_BIG_QUERY_PROJECT_ID: ${{ secrets.TEST_BIG_QUERY_PROJECT_ID }}
-          TEST_BIG_QUERY_PARENT_PROJECT_ID: ${{ secrets.TEST_BIG_QUERY_PARENT_PROJECT_ID }}
-          TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON: ${{ secrets.TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON }}
-          TEST_BIG_QUERY_BUCKET_NAME: ${{ secrets.TEST_BIG_QUERY_BUCKET_NAME }}
-          TEST_DUCKDB_STORAGE_ACCESS_KEY: ${{ secrets.TEST_DUCKDB_STORAGE_ACCESS_KEY }}
-          TEST_DUCKDB_STORAGE_SECRET_KEY: ${{ secrets.TEST_DUCKDB_STORAGE_SECRET_KEY }}
+      - name: unit tests
         run: |
-          ./mvnw test -B --fail-at-end
+          ./mvnw test -B --fail-at-end -pl !:accio-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,121 @@
+# Run secret-dependent integration tests only after /test-with-secrets approval
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  repository_dispatch:
+    types: [ test-with-secrets-command ]
+
+name: Integration tests
+
+jobs:
+  # Branch-based in origin repo pull request
+  integration-trusted:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: build
+        run: |
+          ./mvnw clean install -B -DskipTests
+      - name: integration tests
+        env:
+          TEST_BIG_QUERY_PROJECT_ID: ${{ secrets.TEST_BIG_QUERY_PROJECT_ID }}
+          TEST_BIG_QUERY_PARENT_PROJECT_ID: ${{ secrets.TEST_BIG_QUERY_PARENT_PROJECT_ID }}
+          TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON: ${{ secrets.TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON }}
+          TEST_BIG_QUERY_BUCKET_NAME: ${{ secrets.TEST_BIG_QUERY_BUCKET_NAME }}
+          TEST_DUCKDB_STORAGE_ACCESS_KEY: ${{ secrets.TEST_DUCKDB_STORAGE_ACCESS_KEY }}
+          TEST_DUCKDB_STORAGE_SECRET_KEY: ${{ secrets.TEST_DUCKDB_STORAGE_SECRET_KEY }}
+        run: |
+          ./mvnw test -B --fail-at-end -pl :accio-tests
+
+  # Repo owner has commented /test-with-secrets on a (fork-based) pull request
+  integration-fork:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: write
+    if: |
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+              github.event.client_payload.pull_request.head.sha,
+              github.event.client_payload.slash_command.args.named.sha
+            )
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: |
+            ci link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: build
+        run: |
+          ./mvnw clean install -B -DskipTests
+      - name: integration tests
+        env:
+          TEST_BIG_QUERY_PROJECT_ID: ${{ secrets.TEST_BIG_QUERY_PROJECT_ID }}
+          TEST_BIG_QUERY_PARENT_PROJECT_ID: ${{ secrets.TEST_BIG_QUERY_PARENT_PROJECT_ID }}
+          TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON: ${{ secrets.TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON }}
+          TEST_BIG_QUERY_BUCKET_NAME: ${{ secrets.TEST_BIG_QUERY_BUCKET_NAME }}
+          TEST_DUCKDB_STORAGE_ACCESS_KEY: ${{ secrets.TEST_DUCKDB_STORAGE_ACCESS_KEY }}
+          TEST_DUCKDB_STORAGE_SECRET_KEY: ${{ secrets.TEST_DUCKDB_STORAGE_SECRET_KEY }}
+        run: |
+          ./mvnw test -B --fail-at-end -pl :accio-tests
+      # Update check run called "integration-fork"
+      - uses: actions/github-script@v6
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+
+            return result;

--- a/.github/workflows/test-with-secrets.yml
+++ b/.github/workflows/test-with-secrets.yml
@@ -1,0 +1,35 @@
+# If someone with write access comments "/test-with-secrets" on a pull request, emit a repository_dispatch event
+name: test-with-secrets
+
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  test-with-secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    # Only run for PRs, not issue comments and not on forks
+    if: ${{ github.event.issue.pull_request }} && github.repository_owner == 'Canner'
+    steps:
+      # Generate a GitHub App installation access token from an App ID and private key
+      # To create a new GitHub App:
+      #   https://developer.github.com/apps/building-github-apps/creating-a-github-app/
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        env:
+          TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          token: ${{ env.TOKEN }} # GitHub App installation access token
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: test-with-secrets
+          permission: write


### PR DESCRIPTION
follow https://github.com/imjohnbo/ok-to-test

As someone with write access, comment /test-with-secrets sha=<head-sha> on an incoming pull request. The head sha is the first seven characters of the most recent commit of the incoming pull request.

Here is the recommended flow:
- A fork pull request is opened.
- A unit test workflow runs. Secrets are not available to this workflow.
- Someone with [write access](https://help.github.com/en/github/getting-started-with-github/access-permissions-on-github) looks over the pull request code. ⚠️ Before proceeding, they should be sure the code isn't doing anything malicious like secret logging. ⚠️
- They comment /test-with-secrets sha=<head-sha> on the pull request.
- A repository_dispatch API request is sent to this repository. 
- An integration test workflow runs, secrets are available to this workflow.
- The pull request status check is updated to reflect the success or failure of the integration test workflow.