### PR TITLE
Implement metric lineage analysis for models

### DIFF
--- a/accio-base/src/main/java/io/accio/base/dto/AccioObject.java
+++ b/accio-base/src/main/java/io/accio/base/dto/AccioObject.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.dto;
+
+import java.util.List;
+
+public interface AccioObject
+{
+    String getName();
+
+    List<String> getColumnNames();
+}

--- a/accio-base/src/main/java/io/accio/base/dto/Metric.java
+++ b/accio-base/src/main/java/io/accio/base/dto/Metric.java
@@ -16,6 +16,7 @@ package io.accio.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 
 import java.util.List;
@@ -24,9 +25,10 @@ import java.util.Optional;
 
 import static io.accio.base.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 public class Metric
-        implements PreAggregationInfo
+        implements PreAggregationInfo, AccioObject
 {
     private final String name;
     private final String baseModel;
@@ -179,5 +181,15 @@ public class Metric
                 ", refreshTime=" + refreshTime +
                 ", description='" + description + '\'' +
                 '}';
+    }
+
+    @Override
+    public List<String> getColumnNames()
+    {
+        return ImmutableList.<String>builder()
+                .addAll(dimension.stream().map(Column::getName).collect(toList()))
+                .addAll(measure.stream().map(Column::getName).collect(toList()))
+                .addAll(timeGrain.stream().map(TimeGrain::getRefColumn).collect(toList()))
+                .build();
     }
 }

--- a/accio-base/src/main/java/io/accio/base/dto/Model.java
+++ b/accio-base/src/main/java/io/accio/base/dto/Model.java
@@ -22,9 +22,10 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 public class Model
-        implements PreAggregationInfo
+        implements PreAggregationInfo, AccioObject
 {
     private final String name;
     private final String refSql;
@@ -154,5 +155,11 @@ public class Model
                 ", refreshTime='" + refreshTime + '\'' +
                 ", description='" + description + '\'' +
                 '}';
+    }
+
+    @Override
+    public List<String> getColumnNames()
+    {
+        return columns.stream().map(Column::getName).collect(toList());
     }
 }

--- a/accio-validation/pom.xml
+++ b/accio-validation/pom.xml
@@ -16,12 +16,28 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <main-class>io.accio.cli.Accio</main-class>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
         </dependency>
 
         <dependency>
@@ -32,6 +48,11 @@
         <dependency>
             <groupId>io.accio</groupId>
             <artifactId>trino-parser</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jgrapht</groupId>
+            <artifactId>jgrapht-core</artifactId>
         </dependency>
 
         <dependency>
@@ -58,4 +79,49 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>executable</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>${main-class}</Main-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.skife.maven</groupId>
+                <artifactId>really-executable-jar-maven-plugin</artifactId>
+                <configuration>
+                    <classifier>executable</classifier>
+                    <programFile>accio-cli</programFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/accio-validation/src/main/java/io/accio/Utils.java
+++ b/accio-validation/src/main/java/io/accio/Utils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio;
+
+import io.trino.sql.parser.ParsingOptions;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.DereferenceExpression;
+import io.trino.sql.tree.Expression;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
+
+public class Utils
+{
+    private Utils() {}
+
+    public static final SqlParser SQL_PARSER = new SqlParser();
+    private static final ParsingOptions PARSING_OPTIONS = new ParsingOptions(AS_DECIMAL);
+
+    public static Expression parseExpression(String expression)
+    {
+        return SQL_PARSER.createExpression(expression, PARSING_OPTIONS);
+    }
+
+    public static Expression removePrefix(DereferenceExpression dereferenceExpression, int removeFirstN)
+    {
+        return parseExpression(
+                Arrays.stream(dereferenceExpression.toString().split("\\."))
+                        .skip(removeFirstN)
+                        .collect(Collectors.joining(".")));
+    }
+}

--- a/accio-validation/src/main/java/io/accio/cli/Accio.java
+++ b/accio-validation/src/main/java/io/accio/cli/Accio.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.cli;
+
+import picocli.CommandLine;
+
+public class Accio
+{
+    private Accio() {}
+
+    public static void main(String[] args)
+    {
+        System.exit(createCommandLine(new AccioMainCommand()).execute(args));
+    }
+
+    public static CommandLine createCommandLine(Object command)
+    {
+        return new CommandLine(command)
+                .addSubcommand("metric-lineage", new MetricLineage());
+    }
+}

--- a/accio-validation/src/main/java/io/accio/cli/AccioMainCommand.java
+++ b/accio-validation/src/main/java/io/accio/cli/AccioMainCommand.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.cli;
+
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "accio-cli", mixinStandardHelpOptions = true, version = "accio-0.1.0",
+        description = "Accio: A tool for analyzing data lineage")
+public class AccioMainCommand
+        implements Callable<Integer>
+{
+    @Override
+    public Integer call()
+            throws Exception
+    {
+        return 1;
+    }
+}

--- a/accio-validation/src/main/java/io/accio/cli/MetricLineage.java
+++ b/accio-validation/src/main/java/io/accio/cli/MetricLineage.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.cli;
+
+import io.accio.base.AccioMDL;
+import io.accio.base.dto.AccioObject;
+import io.accio.base.dto.Metric;
+import io.accio.lineage.MetricLineageAnalyzer;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.traverse.DepthFirstIterator;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import static java.lang.String.format;
+
+@CommandLine.Command(name = "metric-lineage", mixinStandardHelpOptions = true, version = "accio-0.1.0",
+        description = "Analyze metric lineage")
+public class MetricLineage
+        implements Callable<Integer>
+{
+    @CommandLine.Option(names = "-i", required = true, description = "The path of Accio MDL file")
+    private File accioMDLFile;
+
+    @CommandLine.Option(names = "-m", description = "The name of the specific model. If not specified, all models will be analyzed")
+    private String targetModelName;
+
+    public boolean run()
+            throws IOException
+    {
+        AccioMDL accioMDL = importAccioMDL(accioMDLFile.toPath());
+        Graph<AccioObject, DefaultEdge> graph = MetricLineageAnalyzer.analyze(accioMDL);
+        if (targetModelName != null) {
+            AccioObject targetModel = accioMDL.getModel(targetModelName).orElseThrow(() -> new RuntimeException(format("Model %s not found", targetModelName)));
+            new DepthFirstIterator<>(graph, targetModel).forEachRemaining(this::printAccioObject);
+        }
+        else {
+            accioMDL.listModels().forEach(model ->
+                    new DepthFirstIterator<>(graph, model).forEachRemaining(this::printAccioObject));
+        }
+        return true;
+    }
+
+    private void printAccioObject(AccioObject accioObject)
+    {
+        if (accioObject instanceof Metric) {
+            System.out.println("  " + accioObject.getName());
+        }
+        else {
+            System.out.println("Model: " + accioObject.getName());
+        }
+    }
+
+    @Override
+    public Integer call()
+            throws Exception
+    {
+        return run() ? 0 : 1;
+    }
+
+    private static AccioMDL importAccioMDL(Path path)
+            throws IOException
+    {
+        return AccioMDL.fromJson(Files.readString(path));
+    }
+}

--- a/accio-validation/src/main/java/io/accio/lineage/MetricLineageAnalyzer.java
+++ b/accio-validation/src/main/java/io/accio/lineage/MetricLineageAnalyzer.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.lineage;
+
+import io.accio.Utils;
+import io.accio.base.AccioMDL;
+import io.accio.base.dto.AccioObject;
+import io.accio.base.dto.Metric;
+import io.accio.base.dto.Model;
+import io.airlift.log.Logger;
+import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.DereferenceExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.SubscriptExpression;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class MetricLineageAnalyzer
+{
+    private static final Logger LOG = Logger.get(MetricLineageAnalyzer.class);
+
+    private MetricLineageAnalyzer() {}
+
+    public static Graph<AccioObject, DefaultEdge> analyze(AccioMDL accioMDL)
+    {
+        Graph<AccioObject, DefaultEdge> graph = createSimpleDirectedGraph();
+        accioMDL.listModels().forEach(graph::addVertex);
+        accioMDL.listMetrics().forEach(graph::addVertex);
+
+        // analyze every column in every metric
+        for (Metric metric : accioMDL.listMetrics()) {
+            LOG.debug("Analyzing metric %s", metric.getName());
+            ExpressionVisitor expressionVisitor = new ExpressionVisitor(graph, accioMDL, metric);
+            Model baseModel = accioMDL.getModel(metric.getBaseModel()).orElseThrow(() -> new RuntimeException(format("Model %s not found", metric.getBaseModel())));
+            graph.addEdge(baseModel, metric);
+            metric.getDimension().forEach(column -> expressionVisitor.process(Utils.parseExpression(column.getExpression().orElse(column.getName())), metric));
+        }
+        return graph;
+    }
+
+    private static Graph<AccioObject, DefaultEdge> createSimpleDirectedGraph()
+    {
+        return GraphTypeBuilder
+                .<AccioObject, DefaultEdge>directed()
+                .allowingMultipleEdges(false)
+                .allowingSelfLoops(false)
+                .weighted(false)
+                .edgeClass(DefaultEdge.class)
+                .buildGraph();
+    }
+
+    private static class ExpressionVisitor
+            extends AstVisitor<AccioObject, AccioObject>
+    {
+        private final Graph<AccioObject, DefaultEdge> graph;
+        private final AccioMDL accioMDL;
+        private final AccioObject baseObject;
+
+        private ExpressionVisitor(Graph<AccioObject, DefaultEdge> graph, AccioMDL accioMDL, AccioObject baseObject)
+        {
+            this.graph = requireNonNull(graph, "graph is null");
+            this.accioMDL = requireNonNull(accioMDL, "accioMDL is null");
+            this.baseObject = requireNonNull(baseObject, "baseObject is null");
+        }
+
+        @Override
+        protected AccioObject visitDereferenceExpression(DereferenceExpression node, AccioObject baseObject)
+        {
+            Expression first = getFirst(node);
+            AccioObject firstObject = process(first, baseObject);
+
+            Expression remainder = Utils.removePrefix(node, 1);
+            process(remainder, firstObject);
+            return baseObject;
+        }
+
+        @Override
+        protected AccioObject visitIdentifier(Identifier node, AccioObject context)
+        {
+            String resolved;
+            if (context instanceof Metric) {
+                Metric metric = (Metric) context;
+                resolved = accioMDL.getModel(metric.getBaseModel())
+                        .orElseThrow(() -> new RuntimeException(format("Model %s not found", metric.getBaseModel())))
+                        .getColumnNames().stream().filter(columnName -> columnName.equals(node.getValue()))
+                        .findAny().orElseThrow(() -> new RuntimeException(format("Column %s not found in %s", node.getValue(), metric.getBaseModel())));
+            }
+            else {
+                resolved = context.getColumnNames().stream().filter(columnName -> columnName.equals(node.getValue()))
+                        .findAny().orElseThrow(() -> new RuntimeException(format("Column %s not found in %s", node.getValue(), context.getName())));
+            }
+
+            Optional<Model> modelOptional = accioMDL.getModel(context.getName());
+            if (modelOptional.isPresent()) {
+                Optional<AccioObject> relatedOptional = modelOptional.get().getColumns().stream()
+                        .filter(column -> column.getName().equals(resolved))
+                        .filter(column -> column.getRelationship().isPresent())
+                        .findAny()
+                        .map(column -> accioMDL.getModel(column.getType()).orElseThrow(() -> new RuntimeException(format("Model %s not found", column.getType()))));
+                relatedOptional
+                        .ifPresent(relatedModel -> graph.addEdge(relatedModel, baseObject));
+                return relatedOptional.orElse(context);
+            }
+
+            Optional<Model> baseModelOptional = accioMDL.getMetric(context.getName())
+                    .map(metric -> accioMDL.getModel(metric.getBaseModel()).orElseThrow(() -> new RuntimeException(format("Model %s not found", metric.getBaseModel()))));
+            if (baseModelOptional.isPresent()) {
+                Optional<AccioObject> relatedOptional = baseModelOptional.get().getColumns().stream()
+                        .filter(column -> column.getName().equals(resolved))
+                        .filter(column -> column.getRelationship().isPresent())
+                        .findAny()
+                        .map(column -> accioMDL.getModel(column.getType()).orElseThrow(() -> new RuntimeException(format("Model %s not found", column.getType()))));
+                relatedOptional
+                        .ifPresent(relatedModel -> graph.addEdge(relatedModel, baseObject));
+                return relatedOptional.orElse(context);
+            }
+            return context;
+        }
+    }
+
+    private static Expression getFirst(Expression expression)
+    {
+        if (expression instanceof DereferenceExpression) {
+            return getFirst(((DereferenceExpression) expression).getBase());
+        }
+        else if (expression instanceof SubscriptExpression) {
+            return getFirst(((SubscriptExpression) expression).getBase());
+        }
+        return expression;
+    }
+}

--- a/accio-validation/src/test/java/io/accio/lineage/TestMetricLineageAnalyzer.java
+++ b/accio-validation/src/test/java/io/accio/lineage/TestMetricLineageAnalyzer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.lineage;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+import io.accio.base.AccioMDL;
+import io.accio.base.dto.AccioObject;
+import io.accio.base.dto.Model;
+import io.accio.testing.AbstractTestFramework;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.traverse.DepthFirstIterator;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class TestMetricLineageAnalyzer
+        extends AbstractTestFramework
+{
+    private final AccioMDL accioMDL;
+
+    public TestMetricLineageAnalyzer()
+            throws IOException
+    {
+        accioMDL = AccioMDL.fromJson(Files.readString(Path.of(requireNonNull(getClass().getClassLoader().getResource("tpch_mdl.json")).getPath())));
+    }
+
+    @Test
+    public void testMetricLineageAnalyzer()
+    {
+        Graph<AccioObject, DefaultEdge> graph = MetricLineageAnalyzer.analyze(accioMDL);
+        assertRelatedObject("Orders", ImmutableSet.of("Orders", "Revenue", "RevenueByNation"), graph);
+        assertRelatedObject("Customer", ImmutableSet.of("Customer", "ConsumptionCustomer", "RevenueByNation"), graph);
+        assertRelatedObject("Nation", ImmutableSet.of("Nation", "ConsumptionCustomer", "RevenueByNation"), graph);
+    }
+
+    private void assertRelatedObject(String startName, Set<String> expectedNames, Graph<AccioObject, DefaultEdge> graph)
+    {
+        Model model = accioMDL.getModel(startName)
+                .orElseThrow(() -> new RuntimeException("Orders model not found"));
+        Iterable<AccioObject> ordersRelatedIterable = () -> new DepthFirstIterator<>(graph, model);
+        Set<String> modelRelated = Streams.stream(ordersRelatedIterable).map(AccioObject::getName).collect(Collectors.toSet());
+        assertThat(modelRelated).isEqualTo(expectedNames);
+    }
+}

--- a/accio-validation/src/test/resources/tpch_mdl.json
+++ b/accio-validation/src/test/resources/tpch_mdl.json
@@ -1,0 +1,385 @@
+{
+  "catalog": "canner-cml",
+  "schema": "tpch_tiny",
+  "models": [
+    {
+      "name": "Orders",
+      "refSql": "select * from \"canner-cml\".tpch_tiny.orders",
+      "columns": [
+        {
+          "name": "orderkey",
+          "expression": "o_orderkey",
+          "type": "int4"
+        },
+        {
+          "name": "custkey",
+          "expression": "o_custkey",
+          "type": "int4"
+        },
+        {
+          "name": "orderstatus",
+          "expression": "o_orderstatus",
+          "type": "OrderStatus"
+        },
+        {
+          "name": "totalprice",
+          "expression": "o_totalprice",
+          "type": "float8"
+        },
+        {
+          "name": "customer",
+          "type": "Customer",
+          "relationship": "OrdersCustomer"
+        },
+        {
+          "name": "orderdate",
+          "expression": "o_orderdate",
+          "type": "date"
+        },
+        {
+          "name": "lineitems",
+          "type": "Lineitem",
+          "relationship": "OrdersLineitem"
+        }
+      ],
+      "primaryKey": "orderkey"
+    },
+    {
+      "name": "Customer",
+      "refSql": "select * from \"canner-cml\".tpch_tiny.customer",
+      "columns": [
+        {
+          "name": "custkey",
+          "expression": "c_custkey",
+          "type": "int4"
+        },
+        {
+          "name": "nationkey",
+          "expression": "c_nationkey",
+          "type": "integer"
+        },
+        {
+          "name": "name",
+          "expression": "c_name",
+          "type": "varchar"
+        },
+        {
+          "name": "orders",
+          "type": "Orders",
+          "relationship": "OrdersCustomer"
+        },
+        {
+          "name": "nation",
+          "type": "Nation",
+          "relationship": "CustomerNation"
+        }
+      ],
+      "primaryKey": "custkey"
+    },
+    {
+      "name": "Lineitem",
+      "refSql": "select * from \"canner-cml\".tpch_tiny.lineitem",
+      "columns": [
+        {
+          "name": "orderkey",
+          "expression": "l_orderkey",
+          "type": "int4"
+        },
+        {
+          "name": "partkey",
+          "expression": "l_partkey",
+          "type": "int4"
+        },
+        {
+          "name": "linenumber",
+          "expression": "l_linenumber",
+          "type": "int4"
+        },
+        {
+          "name": "extendedprice",
+          "expression": "l_extendedprice",
+          "type": "float8"
+        },
+        {
+          "name": "discount",
+          "expression": "l_discount",
+          "type": "float8"
+        },
+        {
+          "name": "shipdate",
+          "expression": "l_shipdate",
+          "type": "date"
+        },
+        {
+          "name": "order",
+          "type": "Orders",
+          "relationship": "OrdersLineitem"
+        },
+        {
+          "name": "part",
+          "type": "Part",
+          "relationship": "LineitemPart"
+        },
+        {
+          "name": "orderkey_linenumber",
+          "type": "varchar",
+          "expression": "concat(l_orderkey, l_linenumber)"
+        }
+      ],
+      "primaryKey": "orderkey_linenumber"
+    },
+    {
+      "name": "Part",
+      "refSql": "select * from \"canner-cml\".tpch_tiny.part",
+      "columns": [
+        {
+          "name": "partkey",
+          "expression": "p_partkey",
+          "type": "int4"
+        },
+        {
+          "name": "name",
+          "expression": "p_name",
+          "type": "varchar"
+        }
+      ],
+      "primaryKey": "partkey"
+    },
+    {
+      "name": "Nation",
+      "refSql": "select * from \"canner-cml\".tpch_tiny.nation",
+      "columns": [
+        {
+          "name": "nationkey",
+          "expression": "n_nationkey",
+          "type": "int4"
+        },
+        {
+          "name": "name",
+          "expression": "n_name",
+          "type": "varchar"
+        },
+        {
+          "name": "regionkey",
+          "expression": "n_regionkey",
+          "type": "int4"
+        },
+        {
+          "name": "comment",
+          "expression": "n_comment",
+          "type": "varchar"
+        },
+        {
+          "name": "region",
+          "type": "Region",
+          "relationship": "NationRegion"
+        },
+        {
+          "name": "customer",
+          "type": "Customer",
+          "relationship": "CustomerNation"
+        },
+        {
+          "name": "supplier",
+          "type": "Supplier",
+          "relationship": "NationSupplier"
+        }
+      ],
+      "primaryKey": "nationkey"
+    },
+    {
+      "name": "Region",
+      "refSql": "select * from \"canner-cml\".tpch_tiny.region",
+      "columns": [
+        {
+          "name": "regionkey",
+          "expression": "r_regionkey",
+          "type": "int4"
+        },
+        {
+          "name": "name",
+          "expression": "r_name",
+          "type": "varchar"
+        },
+        {
+          "name": "comment",
+          "expression": "r_comment",
+          "type": "varchar"
+        },
+        {
+          "name": "nations",
+          "type": "Nation",
+          "relationship": "NationRegion"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "name": "OrdersCustomer",
+      "models": [
+        "Orders",
+        "Customer"
+      ],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Orders.custkey = Customer.custkey"
+    },
+    {
+      "name": "OrdersLineitem",
+      "models": [
+        "Orders",
+        "Lineitem"
+      ],
+      "joinType": "ONE_TO_MANY",
+      "condition": "Orders.orderkey = Lineitem.orderkey"
+    },
+    {
+      "name": "LineitemPart",
+      "models": [
+        "Lineitem",
+        "Part"
+      ],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Lineitem.partkey = Part.partkey"
+    },
+    {
+      "name": "CustomerNation",
+      "models": [
+        "Customer",
+        "Nation"
+      ],
+      "joinType": "MANY_TO_ONE",
+      "condition": "Customer.nationkey = Nation.nationkey"
+    }
+  ],
+  "metrics": [
+    {
+      "name": "Revenue",
+      "baseModel": "Orders",
+      "dimension": [
+        {
+          "name": "custkey",
+          "type": "int4"
+        }
+      ],
+      "measure": [
+        {
+          "name": "totalprice",
+          "type": "int4",
+          "expression": "sum(totalprice)"
+        }
+      ],
+      "timeGrain": [
+        {
+          "name": "orderdate",
+          "refColumn": "orderdate",
+          "dateParts": [
+            "YEAR",
+            "MONTH"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "RevenueByNation",
+      "baseModel": "Orders",
+      "dimension": [
+        {
+          "name": "nation_name",
+          "type": "varchar",
+          "expression": "customer.nation.name"
+        },
+        {
+          "name": "orderstatus",
+          "type": "OrderStatus"
+        }
+      ],
+      "measure": [
+        {
+          "name": "totalprice",
+          "type": "int4",
+          "expression": "sum(totalprice)"
+        }
+      ],
+      "timeGrain": [
+        {
+          "name": "orderdate",
+          "refColumn": "orderdate",
+          "dateParts": [
+            "YEAR",
+            "MONTH"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ConsumptionCustomer",
+      "baseModel": "Customer",
+      "dimension": [
+        {
+          "name": "name",
+          "type": "varchar"
+        },
+        {
+          "name": "region_name",
+          "type": "varchar",
+          "expression": "nation.region.name"
+        }
+      ],
+      "measure": [
+        {
+          "name": "consumption",
+          "type": "int4",
+          "expression": "array_sum(transform(orders, o -> o.totalprice))"
+        }
+      ],
+      "timeGrain": []
+    }
+  ],
+  "enumDefinitions": [
+    {
+      "name": "Status",
+      "values": [
+        {
+          "name": "F"
+        },
+        {
+          "name": "O"
+        },
+        {
+          "name": "P"
+        }
+      ]
+    }
+  ],
+  "views": [
+    {
+      "name": "useModel",
+      "statement": "select * from Orders"
+    },
+    {
+      "name": "useRelationship",
+      "statement": "select orderkey, customer.name from Orders"
+    },
+    {
+      "name": "useRelationshipCustomer",
+      "statement": "select name, array_length(orders) as length from Customer"
+    },
+    {
+      "name": "useMetric",
+      "statement": "select * from Revenue"
+    },
+    {
+      "name": "useMetricRollUp",
+      "statement": "select * from roll_up(Revenue, orderdate, YEAR)"
+    },
+    {
+      "name": "useUseMetric",
+      "statement": "select * from useMetric"
+    },
+    {
+      "name": "useAny",
+      "statement": "SELECT any(filter(orders, orderItem -> orderItem.orderstatus = 'F')).totalprice FROM Customer LIMIT 100"
+    }
+  ]
+}

--- a/docker/build-local.sh
+++ b/docker/build-local.sh
@@ -15,6 +15,8 @@ popd
 
 WORK_DIR="$(mktemp -d)"
 cp ${SOURCE_DIR}/accio-server/target/accio-server-${ACCIO_VERSION}-executable.jar ${WORK_DIR}
+cp ${SOURCE_DIR}/accio-validation/target/accio-cli ${WORK_DIR}
+
 
 CONTAINER="accio:${ACCIO_VERSION}"
 

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,12 @@
             </dependency>
 
             <dependency>
+                <groupId>info.picocli</groupId>
+                <artifactId>picocli</artifactId>
+                <version>4.6.1</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.accio</groupId>
                 <artifactId>accio-base</artifactId>
                 <version>${project.version}</version>
@@ -368,6 +374,12 @@
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>19.0.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jgrapht</groupId>
+                <artifactId>jgrapht-core</artifactId>
+                <version>1.5.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR implement the basic analyzer for metric lineage which can list all metrics extended to the specific model.

## How to use
- Build  `accio-validation` module
```
./mvnw clean install -DskipTests -am -pl :accio-validation
```
- Get an executable file called `accio-cli` in `accio-validation/target`
- Execute this file with the require options
```
./accio-cli metric-lineage -i {the path of  manifest json file} -m {the target model name}
```

More details about the command:
```
Usage: accio-cli metric-lineage [-hV] -i=<accioMDLFile> [-m=<targetModelName>]
Analyze metric lineage
  -h, --help              Show this help message and exit.
  -i=<accioMDLFile>       The path of Accio MDL file
  -m=<targetModelName>    The name of the specific model. If not specified, all
                            models will be analyzed
  -V, --version           Print version information and exit.
```

The sample result:
```
jax@jax-canner:~  $  ./accio-cli metric-lineage -i tpch_mdl.json -m Orders
Model: Orders
  RevenueByNation
  Revenue
```