### PR TITLE
Generate cache data on a per-table basis

### DIFF
--- a/accio-base/src/main/java/io/accio/base/CatalogSchemaTableName.java
+++ b/accio-base/src/main/java/io/accio/base/CatalogSchemaTableName.java
@@ -25,6 +25,11 @@ import static java.util.Objects.requireNonNull;
 
 public final class CatalogSchemaTableName
 {
+    public static CatalogSchemaTableName catalogSchemaTableName(String catalogName, String schemaName, String tableName)
+    {
+        return new CatalogSchemaTableName(catalogName, new SchemaTableName(schemaName, tableName));
+    }
+
     private final String catalogName;
     private final SchemaTableName schemaTableName;
 

--- a/accio-main/src/main/java/io/accio/main/AccioManager.java
+++ b/accio-main/src/main/java/io/accio/main/AccioManager.java
@@ -45,7 +45,7 @@ public class AccioManager
         this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
         if (accioMDLFile.exists()) {
             loadAccioMDLFromFile();
-            cacheManager.createTaskUtilDone(getAccioMDL());
+            cacheManager.createTaskUntilDone(getAccioMDL());
         }
         else {
             LOG.warn("AccioMDL file %s does not exist", accioMDLFile);

--- a/accio-main/src/main/java/io/accio/main/AccioManager.java
+++ b/accio-main/src/main/java/io/accio/main/AccioManager.java
@@ -62,7 +62,7 @@ public class AccioManager
             throws JsonProcessingException
     {
         AccioMDL oldAccioMDL = accioMDL.get();
-        cacheManager.removeCache(oldAccioMDL.getCatalog(), oldAccioMDL.getSchema());
+        cacheManager.removeCacheIfExist(oldAccioMDL.getCatalog(), oldAccioMDL.getSchema());
         accioMDL.set(AccioMDL.fromJson(json));
     }
 

--- a/accio-main/src/main/java/io/accio/main/web/CacheResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/CacheResource.java
@@ -66,7 +66,7 @@ public class CacheResource
 
     @GET
     @Path("info/{catalogName}/{schemaName}/{tableName}")
-    public void getTaskInfos(
+    public void getTaskInfo(
             @PathParam("catalogName") String catalogName,
             @PathParam("schemaName") String schemaName,
             @PathParam("tableName") String tableName,

--- a/accio-main/src/main/java/io/accio/main/web/CacheResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/CacheResource.java
@@ -51,7 +51,7 @@ public class CacheResource
     @Path("reload")
     public void reload(@Suspended AsyncResponse asyncResponse)
     {
-        cacheManager.createTaskUtilDone(accioManager.getAccioMDL());
+        cacheManager.createTaskUntilDone(accioManager.getAccioMDL());
         asyncResponse.resume(Response.ok().build());
     }
 
@@ -66,7 +66,7 @@ public class CacheResource
 
     @GET
     @Path("info/{catalogName}/{schemaName}/{tableName}")
-    public void getTaskInfo(
+    public void getTaskInfos(
             @PathParam("catalogName") String catalogName,
             @PathParam("schemaName") String schemaName,
             @PathParam("tableName") String tableName,
@@ -81,7 +81,7 @@ public class CacheResource
 
     @GET
     @Path("info/{catalogName}/{schemaName}")
-    public void getTaskInfo(
+    public void getTaskInfos(
             @PathParam("catalogName") String catalogName,
             @PathParam("schemaName") String schemaName,
             @Suspended AsyncResponse asyncResponse)

--- a/accio-main/src/main/java/io/accio/main/web/CacheResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/CacheResource.java
@@ -14,6 +14,8 @@
 package io.accio.main.web;
 
 import io.accio.base.AccioException;
+import io.accio.base.CatalogSchemaTableName;
+import io.accio.base.metadata.SchemaTableName;
 import io.accio.cache.CacheManager;
 import io.accio.main.AccioManager;
 
@@ -63,14 +65,29 @@ public class CacheResource
     }
 
     @GET
-    @Path("reload/async/{taskId}")
-    public void getTaskInfoByTaskId(
-            @PathParam("taskId") String taskId,
+    @Path("info/{catalogName}/{schemaName}/{tableName}")
+    public void getTaskInfo(
+            @PathParam("catalogName") String catalogName,
+            @PathParam("schemaName") String schemaName,
+            @PathParam("tableName") String tableName,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(catalogName, new SchemaTableName(schemaName, tableName));
+        cacheManager
+                .getTaskInfo(catalogSchemaTableName)
+                .thenApply(v -> v.orElseThrow(() -> new AccioException(NOT_FOUND, String.format("Task %s not found.", catalogSchemaTableName))))
+                .whenComplete(bindAsyncResponse(asyncResponse));
+    }
+
+    @GET
+    @Path("info/{catalogName}/{schemaName}")
+    public void getTaskInfo(
+            @PathParam("catalogName") String catalogName,
+            @PathParam("schemaName") String schemaName,
             @Suspended AsyncResponse asyncResponse)
     {
         cacheManager
-                .getTaskInfo(taskId)
-                .thenApply(v -> v.orElseThrow(() -> new AccioException(NOT_FOUND, String.format("Task %s not found.", taskId))))
+                .listTaskInfo(catalogName, schemaName)
                 .whenComplete(bindAsyncResponse(asyncResponse));
     }
 }

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestRefreshCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestRefreshCache.java
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
 import static io.accio.base.CatalogSchemaTableName.catalogSchemaTableName;
 import static io.accio.cache.TaskInfo.TaskStatus.RUNNING;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
@@ -53,7 +53,6 @@ public class TestRefreshCache
         TaskInfo original = cacheManager.get().listTaskInfo(mdl.getCatalog(), mdl.getSchema()).join().stream()
                 .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(revenueName))
                 .findAny().orElseThrow(AssertionError::new);
-        Thread.sleep(6000);
         // make sure the end time will be changed.
         TaskInfo refreshed = getTaskInfoUntilDifferent(original);
         assertThat(original.getEndTime()).isBefore(refreshed.getEndTime());
@@ -71,7 +70,7 @@ public class TestRefreshCache
                     .filter(t -> t.getTableName().equals(taskInfo.getTableName()))
                     .findAny().orElseThrow(AssertionError::new);
             try {
-                SECONDS.sleep(1);
+                MILLISECONDS.sleep(100);
             }
             catch (InterruptedException ignored) {
             }

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestRefreshCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestRefreshCache.java
@@ -16,12 +16,18 @@ package io.accio.testing.bigquery;
 
 import com.google.inject.Key;
 import io.accio.base.AccioMDL;
+import io.accio.base.CatalogSchemaTableName;
+import io.accio.base.dto.CacheInfo;
+import io.accio.cache.TaskInfo;
 import io.accio.main.AccioMetastore;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static io.accio.base.CatalogSchemaTableName.catalogSchemaTableName;
+import static io.accio.cache.TaskInfo.TaskStatus.RUNNING;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,14 +47,18 @@ public class TestRefreshCache
     public void testRefreshFrequently()
             throws InterruptedException
     {
-        // manually reload cache
-        cacheManager.get().createTaskUtilDone(accioMDL.get());
-        // We have one cached table and the most tables existing in duckdb is 2
-        assertThat(queryDuckdb("show tables").size()).isLessThan(3);
-        for (int i = 0; i < 50; i++) {
-            Thread.sleep(200);
-            assertThat(queryDuckdb("show tables").size()).isLessThan(3);
-        }
+        AccioMDL mdl = accioMDL.get();
+        CatalogSchemaTableName revenueName = catalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), "RefreshFrequently");
+        TaskInfo original = cacheManager.get().listTaskInfo(mdl.getCatalog(), mdl.getSchema()).join().stream()
+                .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(revenueName))
+                .findAny().orElseThrow(AssertionError::new);
+
+        Thread.sleep(6000);
+        TaskInfo refreshed = cacheManager.get().listTaskInfo(mdl.getCatalog(), mdl.getSchema()).join().stream()
+                .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(revenueName))
+                .findAny().orElseThrow(AssertionError::new);
+
+        assertThat(original.getEndTime()).isBefore(refreshed.getEndTime());
     }
 
     // todo need a proper test
@@ -61,5 +71,44 @@ public class TestRefreshCache
         Thread.sleep(3000);
         String after = getDefaultCacheInfoPair("RefreshFrequently").getRequiredTableName();
         assertThat(before).isNotEqualTo(after);
+    }
+
+    @Test
+    public void testRefreshSingleModel()
+    {
+        AccioMDL mdl = accioMDL.get();
+        List<TaskInfo> taskInfoList = cacheManager.get().listTaskInfo(mdl.getCatalog(), mdl.getSchema()).join();
+        assertThat(taskInfoList.size()).isEqualTo(3);
+
+        CatalogSchemaTableName ordersName = catalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), "Orders");
+        CacheInfo orders = mdl.getCacheInfo(ordersName)
+                .orElseThrow(() -> new RuntimeException("Orders not found"));
+
+        TaskInfo original = taskInfoList.stream()
+                .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(ordersName))
+                .findAny().orElseThrow(AssertionError::new);
+
+        TaskInfo start = cacheManager.get().createTask(mdl, orders).join();
+        assertThat(start.getTaskStatus()).isEqualTo(RUNNING);
+        assertThat(start.getEndTime()).isNull();
+        cacheManager.get().untilTaskDone(ordersName);
+
+        List<TaskInfo> finished = cacheManager.get().listTaskInfo(mdl.getCatalog(), mdl.getSchema()).join();
+        TaskInfo end = finished.stream()
+                .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(ordersName))
+                .findAny().orElseThrow(AssertionError::new);
+        assertThat(end.getTaskStatus()).isEqualTo(TaskInfo.TaskStatus.DONE);
+        assertThat(end.getEndTime()).isAfter(original.getEndTime());
+
+        CatalogSchemaTableName customerName = catalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), "Customer");
+        TaskInfo originalCustomer = taskInfoList.stream()
+                .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(customerName))
+                .findAny().orElseThrow(AssertionError::new);
+
+        // only refresh orders, others should not be affected
+        TaskInfo endCustomer = finished.stream()
+                .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(customerName))
+                .findAny().orElseThrow(AssertionError::new);
+        assertThat(originalCustomer.getEndTime()).isEqualTo(endCustomer.getEndTime());
     }
 }

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestReloadCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestReloadCache.java
@@ -109,7 +109,7 @@ public class TestReloadCache
         List<TaskInfo> taskInfos3 = reloadCacheAsync();
         assertThat(taskInfos3.size()).isEqualTo(1);
         taskInfo = taskInfos3.get(0);
-        // assertThat(taskInfo.getTaskStatus()).isEqualTo(RUNNING);
+        assertThat(taskInfo.getTaskStatus()).isEqualTo(RUNNING);
         taskInfo = waitUntilFinished(taskInfo.getCatalogSchemaTableName());
         cachedTable = taskInfo.getCachedTable();
         assertThat(cachedTable.getErrorMessage()).isPresent();

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestReloadCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestReloadCache.java
@@ -30,13 +30,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.accio.base.CatalogSchemaTableName.catalogSchemaTableName;
 import static io.accio.base.metadata.StandardErrorCode.NOT_FOUND;
 import static io.accio.cache.TaskInfo.TaskStatus.DONE;
 import static io.accio.cache.TaskInfo.TaskStatus.RUNNING;
 import static io.accio.testing.WebApplicationExceptionAssert.assertWebApplicationException;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,9 +84,12 @@ public class TestReloadCache
 
         rewriteFile("cache/cache_reload_1_mdl.json");
         reloadAccioMDL();
-        TaskInfo taskInfo = reloadCacheAsync();
+
+        List<TaskInfo> taskInfos = reloadCacheAsync();
+        assertThat(taskInfos.size()).isEqualTo(1);
+        TaskInfo taskInfo = taskInfos.get(0);
         assertThat(taskInfo.getTaskStatus()).isEqualTo(RUNNING);
-        taskInfo = waitUntilFinished(taskInfo.getTaskId());
+        taskInfo = waitUntilFinished(taskInfo.getCatalogSchemaTableName());
         assertCache("Revenue");
         assertThat(taskInfo.getCatalogName()).isEqualTo("canner-cml");
         assertThat(taskInfo.getSchemaName()).isEqualTo("tpch_tiny");
@@ -95,7 +98,7 @@ public class TestReloadCache
         assertThat(taskInfo.getEndTime()).isNotNull();
         assertThat(taskInfo.getEndTime()).isAfter(taskInfo.getStartTime());
 
-        CachedTable cachedTable = taskInfo.getCachedTables().get(0);
+        CachedTable cachedTable = taskInfo.getCachedTable();
         assertThat(cachedTable.getErrorMessage()).isEmpty();
         assertThat(cachedTable.getName()).isEqualTo("Revenue");
         assertThat(cachedTable.getRefreshTime()).isEqualTo(Duration.valueOf("5m"));
@@ -103,14 +106,16 @@ public class TestReloadCache
 
         rewriteFile("cache/cache_reload_3_mdl.json");
         reloadAccioMDL();
-        taskInfo = reloadCacheAsync();
-        assertThat(taskInfo.getTaskStatus()).isEqualTo(RUNNING);
-        taskInfo = waitUntilFinished(taskInfo.getTaskId());
-        cachedTable = taskInfo.getCachedTables().get(0);
+        List<TaskInfo> taskInfos3 = reloadCacheAsync();
+        assertThat(taskInfos3.size()).isEqualTo(1);
+        taskInfo = taskInfos3.get(0);
+        // assertThat(taskInfo.getTaskStatus()).isEqualTo(RUNNING);
+        taskInfo = waitUntilFinished(taskInfo.getCatalogSchemaTableName());
+        cachedTable = taskInfo.getCachedTable();
         assertThat(cachedTable.getErrorMessage()).isPresent();
         assertThat(taskInfo.getEndTime()).isAfter(taskInfo.getStartTime());
 
-        assertWebApplicationException(() -> getTaskInfoByTaskId(randomUUID().toString()))
+        assertWebApplicationException(() -> getTaskInfo(catalogSchemaTableName("fake", "fake", "fake")))
                 .hasHTTPStatus(404)
                 .hasErrorCode(NOT_FOUND)
                 .hasErrorMessageMatches("Task .* not found.");
@@ -132,13 +137,13 @@ public class TestReloadCache
         Files.copy(Path.of(requireNonNull(getClass().getClassLoader().getResource(resourcePath)).getPath()), accioMDLFilePath, REPLACE_EXISTING);
     }
 
-    private TaskInfo waitUntilFinished(String taskId)
+    private TaskInfo waitUntilFinished(CatalogSchemaTableName name)
             throws InterruptedException, ExecutionException, TimeoutException
     {
         return supplyAsync(() -> {
             TaskInfo taskInfo;
             do {
-                taskInfo = getTaskInfoByTaskId(taskId);
+                taskInfo = getTaskInfo(name);
                 try {
                     SECONDS.sleep(1L);
                 }

--- a/accio-tests/src/test/resources/cache/cache_frequently_mdl.json
+++ b/accio-tests/src/test/resources/cache/cache_frequently_mdl.json
@@ -37,7 +37,8 @@
           "type": "date"
         }
       ],
-      "primaryKey": "orderkey"
+      "primaryKey": "orderkey",
+      "cached": "true"
     },
     {
       "name": "Customer",
@@ -59,7 +60,8 @@
           "relationship": "OrdersCustomer"
         }
       ],
-      "primaryKey": "custkey"
+      "primaryKey": "custkey",
+      "cached": "true"
     }
   ],
   "relationships": [
@@ -101,7 +103,7 @@
           ]
         }
       ],
-      "refreshTime": "100ms"
+      "refreshTime": "5s"
     }
   ]
 }


### PR DESCRIPTION
# What's Changed
- generate cache data on a per-table basis
- create the caching task for each dataset(model & metric)