### PR TITLE
Add jgrapht to shaded

### DIFF
--- a/accio-shaded/pom.xml
+++ b/accio-shaded/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>accio-validation</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jgrapht</groupId>
+            <artifactId>jgrapht-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -73,12 +79,17 @@
                             <artifactSet>
                                 <includes>
                                     <include>io.accio:*</include>
+                                    <include>org.jgrapht:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>io.trino</pattern>
                                     <shadedPattern>${shadeBase}.io.trino</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.jgrapht</pattern>
+                                    <shadedPattern>${shadeBase}.org.jgrapht</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Since trino 375 use a very old version of jgraph (0.9.0) which is far away of what the version in accio (1.5.2). Upgrade jgrapht in trino 375 takes lots of effort. Here we add jgrapht to shaded jar.