### PR TITLE
Fix Define Macro without any parameters

### DIFF
--- a/accio-base/src/main/java/io/accio/base/jinjava/JinjavaExpressionProcessor.java
+++ b/accio-base/src/main/java/io/accio/base/jinjava/JinjavaExpressionProcessor.java
@@ -166,6 +166,8 @@ public class JinjavaExpressionProcessor
         if (matcher.find()) {
             String functionName = matcher.group(1);
             List<Expression> arguments = Arrays.stream(matcher.group(2).split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
                     .map(this::createExpression)
                     .collect(toList());
             Optional<Macro> callee = macros.stream()

--- a/accio-base/src/test/java/io/accio/base/dto/macro/TestMacro.java
+++ b/accio-base/src/test/java/io/accio/base/dto/macro/TestMacro.java
@@ -134,4 +134,34 @@ public class TestMacro
         assertThat(modelOptional.get().getColumns().get(3).getExpression().get()).isEqualTo("'1' || custkey");
         assertThat(modelOptional.get().getColumns().get(4).getExpression().get()).isEqualTo("custkey || name");
     }
+
+    @Test
+    public void testZeroPArameterCall()
+    {
+        Manifest manifest = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("test")
+                .setModels(List.of(
+                        model("Customer",
+                                "select * from main.customer",
+                                List.of(
+                                        column("custkey", INTEGER, null, true),
+                                        column("name", VARCHAR, null, true),
+                                        column("standardTime", INTEGER, null, true, "{{standardTime()}}"),
+                                        column("callStandardTime", INTEGER, null, true, "{{callStandardTime()}}"),
+                                        column("passStandardTime", INTEGER, null, true, "{{passStandardTime(standardTime)}}")),
+                                "pk")))
+                .setMacros(List.of(
+                        macro("standardTime", "() => standardTime"),
+                        macro("callStandardTime", "() => {{callStandardTime()}}"),
+                        macro("passStandardTime", "(cf: Macro) => {{cf()}}")))
+                .build();
+
+        AccioMDL mdl = AccioMDL.fromManifest(manifest);
+        Optional<Model> modelOptional = mdl.getModel("Customer");
+        assertThat(modelOptional).isPresent();
+        assertThat(modelOptional.get().getColumns().get(2).getExpression().get()).isEqualTo("standardTime");
+        assertThat(modelOptional.get().getColumns().get(2).getExpression().get()).isEqualTo("standardTime");
+        assertThat(modelOptional.get().getColumns().get(2).getExpression().get()).isEqualTo("standardTime");
+    }
 }

--- a/accio-base/src/test/java/io/accio/base/jinjava/TestJinjavaExpressionProcessor.java
+++ b/accio-base/src/test/java/io/accio/base/jinjava/TestJinjavaExpressionProcessor.java
@@ -26,6 +26,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class TestJinjavaExpressionProcessor
 {
     List<Macro> macros = List.of(
+            macro("standardTime", "() => standardTime"),
+            macro("callStandardTime", "() => {{ standardTime() }}"),
+            macro("passMacroWithoutParam", "(rule: Macro) => {{ rule() }}"),
             macro("addOne", "(a: Expression) => {{ a }} + 1"),
             macro("addTwo", "(a: Expression) => {{ a }} + 2"),
             macro("callAddOne", "(a: Expression) => {{ addOne(a) }} + 3"),
@@ -46,7 +49,10 @@ public class TestJinjavaExpressionProcessor
                 {"{{ pass4Macro(1, 2, addOne, addTwo) }}", "{{addOne(1)}} + {{addTwo(2)}}"},
                 // TODO: trim the redundant space character
                 {"{{ passMacro(1, addOne) }} + {{ passMacro(2, addTwo) }}", "{{addOne(1)}} + 4  +  {{addTwo(2)}} + 4"},
-                {"{{ passMacro(1, addOne) }} + {{ addOne(1) }}", "{{addOne(1)}} + 4  + {{ addOne(1) }}"}};
+                {"{{ passMacro(1, addOne) }} + {{ addOne(1) }}", "{{addOne(1)}} + 4  + {{ addOne(1) }}"},
+                {"{{ standardTime() }}", "{{ standardTime() }}"},
+                {"{{ callStandardTime() }}", "{{ callStandardTime() }}"},
+                {"{{ passMacroWithoutParam(standardTime) }}", "{{standardTime()}}"}};
         // TODO: unsupported cases: A jinjava expression includes multiple macro calls
         // {"{{ passMacro(1, addOne) + addOne(1) }}", "{{addOne(1)}} + 4 + {{addOne(1)}}"}
         // {"{{ passMacro(1, addOne) + passMacro(2, addTwo) }}", "{{addOne(1)}} + 4 + {{addTwo(2)}} + 4"}


### PR DESCRIPTION
Support the macro definition like:
```
"name": "resolution_time",
"definition": "() => closed_date - created_date"
```