### PR TITLE
Support count_if and array_agg function for BigQuery data source

### DIFF
--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -974,6 +974,34 @@ public class TestWireProtocolWithBigquery
         }
     }
 
+    @Test
+    public void testCountif()
+            throws Exception
+    {
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            ResultSet result = stmt.executeQuery("SELECT count_if(orderkey > 100) FROM Lineitem");
+            result.next();
+            assertThat(result.getLong(1)).isEqualTo(60065L);
+        }
+    }
+
+    @Test
+    public void testArrayAgg()
+            throws Exception
+    {
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            ResultSet result = stmt.executeQuery("SELECT array_agg(distinct if(orderkey < 2, orderkey, null)) FROM Lineitem");
+            result.next();
+            assertThat(result.getArray(1).getArray()).isEqualTo(new Long[] {1L});
+        }
+
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            ResultSet result = stmt.executeQuery("SELECT array_agg(if(orderkey < 3, orderkey, null) order by orderkey asc) FROM Lineitem");
+            result.next();
+            assertThat(result.getArray(1).getArray()).isEqualTo(new Long[] {1L, 1L, 1L, 1L, 1L, 1L, 2L});
+        }
+    }
+
     protected static void assertDefaultPgConfigResponse(TestingWireProtocolClient protocolClient)
             throws IOException
     {


### PR DESCRIPTION
We followed the [Trino function standard](https://trino.io/docs/current/functions/aggregate.html). Then, we should handle the different behavior for each source type.
In this PR, we handle `count_if` and `array_agg` function for bigquery.
- count_if: The function name should be `countif`.
- array_agg: BigQuery doesn't allow null elements in an array. We should add `ignore nulls` for every `array_agg` calling.