### PR TITLE
Add model prefix for identifiers used in measure expression

### DIFF
--- a/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/MetricSqlRender.java
+++ b/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/MetricSqlRender.java
@@ -25,7 +25,13 @@ import io.accio.base.dto.Relationable;
 import io.accio.base.dto.Relationship;
 import io.accio.sqlrewrite.analyzer.ExpressionRelationshipAnalyzer;
 import io.accio.sqlrewrite.analyzer.ExpressionRelationshipInfo;
+import io.trino.sql.SqlFormatter;
+import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.ExpressionRewriter;
+import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.QualifiedName;
 
 import java.util.List;
 import java.util.Map;
@@ -123,7 +129,18 @@ public class MetricSqlRender
         }
 
         if (isMeasure) {
-            return column.getSqlExpression();
+            return SqlFormatter.formatSql(ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<>()
+            {
+                @Override
+                public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+                {
+                    if (baseModel.getColumns().stream().anyMatch(c -> c.getName().equalsIgnoreCase(node.getValue()))) {
+                        return DereferenceExpression.from(QualifiedName.of(baseModel.getName(), node.getValue()));
+                    }
+                    return node;
+                }
+            }, Utils.parseExpression(column.getExpression()
+                    .orElseThrow(() -> new IllegalArgumentException("measure column must have expression")))));
         }
 
         return format("\"%s\".\"%s\" AS \"%s\"", relationable.getBaseObject(), column.getExpression().orElse(column.getName()), column.getName());

--- a/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestMetric.java
+++ b/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestMetric.java
@@ -158,6 +158,11 @@ public class TestMetric
                                 List.of(column("name", VARCHAR, null, true, "order_record.customer.name"),
                                         column("orderdate", DATE, null, true, "order_record.orderdate")),
                                 List.of(column("extAddTotalprice", INTEGER, null, true, "sum(order_record.totalprice + extendedprice)")),
+                                List.of()),
+                        metric("CountOrderkey", "Orders",
+                                List.of(column("orderkey", INTEGER, null, true),
+                                        column("orderdate", DATE, null, true)),
+                                List.of(column("count", INTEGER, null, true, "count(orderkey)")),
                                 List.of())))
                 .build();
         accioMDL = AccioMDL.fromManifest(manifest);
@@ -277,6 +282,14 @@ public class TestMetric
         List<List<Object>> result = query(rewrite("SELECT * FROM testMetricOnMetric ORDER BY orderyear", mdl));
         assertThat(result.get(0).size()).isEqualTo(2);
         assertThat(result.size()).isEqualTo(7);
+    }
+
+    @Test
+    public void testAggregatePrimaryKey()
+    {
+        List<List<Object>> result = query(rewrite("select * from CountOrderkey limit 10"));
+        assertThat(result.get(0).size()).isEqualTo(3);
+        assertThat(result.size()).isEqualTo(10);
     }
 
     private String rewrite(String sql)

--- a/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestMetricViewSqlRewrite.java
+++ b/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestMetricViewSqlRewrite.java
@@ -88,7 +88,7 @@ public class TestMetricViewSqlRewrite
                     "   SELECT\n" +
                     "     \"Album\".\"author\" \"author\"\n" +
                     "   , \"Album\".\"name\" \"album_name\"\n" +
-                    "   , sum(price) \"price\"\n" +
+                    "   , sum(\"Album\".\"price\") \"price\"\n" +
                     "   FROM\n" +
                     "     (\n" +
                     "      SELECT *\n" +
@@ -223,7 +223,7 @@ public class TestMetricViewSqlRewrite
                                 "   SELECT\n" +
                                 "     \"Album\".\"author\" \"author\"\n" +
                                 "   , \"Album\".\"name\" \"album_name\"\n" +
-                                "   , sum(price) \"price\"\n" +
+                                "   , sum(\"Album\".\"price\") \"price\"\n" +
                                 "   FROM\n" +
                                 "     (\n" +
                                 "      SELECT *\n" +
@@ -254,7 +254,7 @@ public class TestMetricViewSqlRewrite
                                 "   SELECT\n" +
                                 "     \"Album\".\"author\" \"author\"\n" +
                                 "   , \"Album\".\"name\" \"album_name\"\n" +
-                                "   , sum(price) \"price\"\n" +
+                                "   , sum(\"Album\".\"price\") \"price\"\n" +
                                 "   FROM\n" +
                                 "     (\n" +
                                 "      SELECT *\n" +


### PR DESCRIPTION
For example, rewrite `count(orderkey)` to `count(Orders.orderkey)`.

