### PR TITLE
Add Event Logger for Cache Event

### DIFF
--- a/accio-cache/src/main/java/io/accio/cache/CacheModule.java
+++ b/accio-cache/src/main/java/io/accio/cache/CacheModule.java
@@ -30,6 +30,7 @@ public class CacheModule
         configBinder(binder).bindConfig(DuckdbS3StyleStorageConfig.class);
         binder.bind(CacheStorageConfig.class).to(DuckdbS3StyleStorageConfig.class).in(Scopes.SINGLETON);
         binder.bind(CacheManager.class).in(Scopes.SINGLETON);
+        binder.bind(EventLogger.class).to(Log4jEventLogger.class).in(Scopes.SINGLETON);
         binder.bind(DuckdbClient.class).in(Scopes.SINGLETON);
         binder.bind(CachedTableMapping.class).to(DefaultCachedTableMapping.class).in(Scopes.SINGLETON);
     }

--- a/accio-cache/src/main/java/io/accio/cache/EventLogger.java
+++ b/accio-cache/src/main/java/io/accio/cache/EventLogger.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.cache;
+
+public interface EventLogger
+{
+    enum Level
+    {
+        INFO,
+        WARN,
+        ERROR
+    }
+
+    void logEvent(Level level, String eventName, TaskInfo event);
+
+    void logEvent(Level level, String eventName, String description);
+}

--- a/accio-cache/src/main/java/io/accio/cache/Log4jEventLogger.java
+++ b/accio-cache/src/main/java/io/accio/cache/Log4jEventLogger.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.accio.cache;
+
+import io.airlift.log.Logger;
+
+public class Log4jEventLogger
+        implements EventLogger
+{
+    private static final Logger LOGGER = Logger.get("CacheEventLogger");
+
+    @Override
+    public void logEvent(Level level, String eventName, TaskInfo event)
+    {
+        logEvent(level, eventName, event.toString());
+    }
+
+    @Override
+    public void logEvent(Level level, String eventName, String description)
+    {
+        switch (level) {
+            case WARN:
+                LOGGER.warn("Event Type: %s, Event: %s", eventName, description);
+                break;
+            case ERROR:
+                LOGGER.error("Event Type: %s, Event: %s", eventName, description);
+                break;
+            default:
+                LOGGER.info("Event Type: %s, Event: %s", eventName, description);
+        }
+    }
+}

--- a/accio-cache/src/main/java/io/accio/cache/TaskInfo.java
+++ b/accio-cache/src/main/java/io/accio/cache/TaskInfo.java
@@ -157,4 +157,16 @@ public class TaskInfo
         this.cachedTable = cachedTable;
         return this;
     }
+
+    @Override
+    public String toString()
+    {
+        return "TaskInfo{" +
+                "catalogSchemaTableName=" + catalogSchemaTableName +
+                ", cachedTable=" + cachedTable +
+                ", taskStatus=" + taskStatus +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                '}';
+    }
 }


### PR DESCRIPTION
Now we have an interface for logging the cache event. There're 2 kind of events will be logged: 
- Create Cache : It include creating a new cache and refreshing a old cache.
- Remove Cache: When remove a cache successfully, it logs this event.

We only provide one implementation for `EventLogger`.
- Log4jEventLogger: Its behavior is depending on how user setup his log4j.properties