### PR TITLE
Fix PGwire-related issues for Metabase

### DIFF
--- a/accio-base/src/main/java/io/accio/base/type/TimestampWithTimeZoneType.java
+++ b/accio-base/src/main/java/io/accio/base/type/TimestampWithTimeZoneType.java
@@ -14,14 +14,43 @@
 
 package io.accio.base.type;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
+import org.joda.time.format.DateTimeFormat;
 
 import javax.annotation.Nonnull;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 
 public class TimestampWithTimeZoneType
         extends BaseTimestampType
 {
     public static final PGType TIMESTAMP_WITH_TIMEZONE = new TimestampWithTimeZoneType();
+    static final DateTimeFormatter PG_TIMESTAMP = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .optionalStart()
+            .appendLiteral(' ')
+            .append(ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendLiteral(' ')
+            .optionalEnd()
+            .appendPattern("[VV][x][xx][xxx][z]")
+            .toFormatter(Locale.ENGLISH).withResolverStyle(ResolverStyle.STRICT);
+
+    private static final org.joda.time.format.DateTimeFormatter ISO_FORMATTER =
+            DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSS+00").withZoneUTC().withLocale(Locale.ENGLISH);
 
     private static final int OID = 1184;
     private static final String NAME = "timestamptz";
@@ -40,18 +69,30 @@ public class TimestampWithTimeZoneType
     @Override
     public byte[] encodeAsUTF8Text(@Nonnull Object value)
     {
-        throw new UnsupportedOperationException();
+        // TODO: consider AD, BC and dynamic fraction precision.
+        if (value instanceof String) {
+            return ((String) value).getBytes(UTF_8);
+        }
+        return ISO_FORMATTER.print(Instant.from((TemporalAccessor) value).getLong(MILLI_OF_SECOND))
+                .getBytes(UTF_8);
     }
 
     @Override
     public Object decodeUTF8Text(byte[] bytes)
     {
-        throw new UnsupportedOperationException();
+        String dtString = new String(bytes, UTF_8);
+        return PG_TIMESTAMP.format(tryParse(dtString));
+    }
+
+    @VisibleForTesting
+    ZonedDateTime tryParse(String timeString)
+    {
+        return ZonedDateTime.parse(timeString, PG_TIMESTAMP);
     }
 
     @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/accio-base/src/test/java/io/accio/base/type/TestTimestampWithTimeZoneTypeParsing.java
+++ b/accio-base/src/test/java/io/accio/base/type/TestTimestampWithTimeZoneTypeParsing.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.accio.base.type;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+
+public class TestTimestampWithTimeZoneTypeParsing
+{
+    @DataProvider
+    public Object[][] timestampWithTimeZone()
+    {
+        return new Object[][] {
+                {"2004-10-19 10:23:54 +02"},
+                {"1999-01-08 04:05:06 PST"},
+                {"1999-01-08 04:05:06 PST8PDT"},
+                {"1999-01-08 04:05:06 zulu"},
+                {"1999-01-08 04:05:06 z"},
+                {"1999-01-08 04:05:06 America/New_York"},
+                {"2004-10-19 10:23:54+02"},
+                {"1999-01-08 04:05:06PST"},
+                {"1999-01-08 04:05:06PST8PDT"},
+                {"1999-01-08 04:05:06zulu"},
+                {"1999-01-08 04:05:06z"},
+
+                // TODO: unsupported pg pattern
+                // {"1999-01-08 04:05:06 -8:00"},
+                // {"1999-01-08 04:05:06-8:00"},
+                // {"1999-01-08 04:05:06 -8:00:00"},
+                // {"1999-01-08 04:05:06 -8:00"},
+                // {"1999-01-08 04:05:06 -800"},
+                // {"1999-01-08 04:05:06-8:00:00"},
+                // {"1999-01-08 04:05:06-8:00"},
+                // {"1999-01-08 04:05:06-800"},
+                // {"1999-01-08 04:05:06-8"},
+                // {"1999-01-08 04:05:06 -8"},
+                // {"1999-01-08 04:05:06Americ/New_York"},
+        };
+    }
+
+    @Test(dataProvider = "timestampWithTimeZone")
+    public void testParsing(String timestampString)
+    {
+        assertThatNoException()
+                .isThrownBy(() -> TimestampWithTimeZoneType.PG_TIMESTAMP.parse(timestampString));
+    }
+}

--- a/accio-connector-client/src/main/java/io/accio/connector/bigquery/BigQueryType.java
+++ b/accio-connector-client/src/main/java/io/accio/connector/bigquery/BigQueryType.java
@@ -27,6 +27,7 @@ import io.accio.base.type.PGType;
 import io.accio.base.type.PGTypes;
 import io.accio.base.type.RecordType;
 import io.accio.base.type.TimestampType;
+import io.accio.base.type.TimestampWithTimeZoneType;
 import org.joda.time.Period;
 
 import java.time.LocalDate;
@@ -99,6 +100,7 @@ public final class BigQueryType
                 .put(NumericType.NUMERIC, BIGNUMERIC)
                 .put(DateType.DATE, DATE)
                 .put(TimestampType.TIMESTAMP, TIMESTAMP)
+                .put(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIMEZONE, TIMESTAMP)
                 .put(BYTEA, BYTES)
                 .put(IntervalType.INTERVAL, INTERVAL)
                 .put(JsonType.JSON, JSON)

--- a/accio-main/src/test/java/io/accio/main/pgcatalog/builder/TestCreateBigQueryTempTable.java
+++ b/accio-main/src/test/java/io/accio/main/pgcatalog/builder/TestCreateBigQueryTempTable.java
@@ -128,7 +128,6 @@ public class TestCreateBigQueryTempTable
                         "('accio_schema', 'OrdersModel', 'clerk', 7, 1043, -1), " +
                         "('accio_schema', 'OrdersModel', 'shippriority', 8, 23, 4), " +
                         "('accio_schema', 'OrdersModel', 'comment', 9, 1043, -1), " +
-                        "('accio_schema', 'OrdersModel', 'customer', 10, 23, 4), " +
                         "('accio_schema', 'LineitemModel', 'orderkey', 1, 23, 4), " +
                         "('accio_schema', 'LineitemModel', 'linenumber', 2, 23, 4), " +
                         "('accio_schema', 'LineitemModel', 'extendedprice', 3, 23, 4), " +
@@ -140,7 +139,6 @@ public class TestCreateBigQueryTempTable
                         "('accio_schema', 'CustomerModel', 'acctbal', 6, 701, 8), " +
                         "('accio_schema', 'CustomerModel', 'mktsegment', 7, 1043, -1), " +
                         "('accio_schema', 'CustomerModel', 'comment', 8, 1043, -1), " +
-                        "('accio_schema', 'CustomerModel', 'orders', 9, 1007, -1), " +
                         "('accio_schema', 'Revenue', 'orderkey', 1, 1043, -1), " +
                         "('accio_schema', 'Revenue', 'total', 2, 23, 4)]);");
 

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -970,7 +970,7 @@ public class TestWireProtocolWithBigquery
             while (result.next()) {
                 columnNames.add(result.getString("COLUMN_NAME"));
             }
-            assertThat(columnNames).containsExactlyInAnyOrder("orderkey", "custkey", "totalprice", "orderdate", "lineitems");
+            assertThat(columnNames).containsExactlyInAnyOrder("orderkey", "custkey", "totalprice", "orderdate");
         }
     }
 


### PR DESCRIPTION
- Remove relationship field from pg_catalog:
A relationship field in a model shold be used in runtime. We can't put them to the pg_catalog.
- Support TIMESTAMP_WITH_TIMEZONE


# Known Issue
There're many time-related filter operation in Metabase. We only support time-specified(ex. range or specified day) operation now.
