### PR TITLE
Add DuckDBConfig to handle the system resource configurations

### DIFF
--- a/accio-base/pom.xml
+++ b/accio-base/pom.xml
@@ -32,6 +32,11 @@
     <dependencies>
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>
 

--- a/accio-base/pom.xml
+++ b/accio-base/pom.xml
@@ -92,6 +92,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/accio-base/src/main/java/io/accio/base/client/duckdb/DuckDBConfig.java
+++ b/accio-base/src/main/java/io/accio/base/client/duckdb/DuckDBConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.accio.base.client.duckdb;
+
+import io.airlift.configuration.Config;
+
+public class DuckDBConfig
+{
+    private String memoryLimit = Runtime.getRuntime().maxMemory() / 2 + "B";
+    private String homeDirectory = "/tmp/duckdb";
+    private String tempDirectory = "/tmp/duck";
+
+    public String getMemoryLimit()
+    {
+        return memoryLimit;
+    }
+
+    @Config("duckdb.memory-limit")
+    public void setMemoryLimit(String memoryLimit)
+    {
+        this.memoryLimit = memoryLimit;
+    }
+
+    public String getHomeDirectory()
+    {
+        return homeDirectory;
+    }
+
+    @Config("duckdb.home-directory")
+    public void setHomeDirectory(String homeDirectory)
+    {
+        this.homeDirectory = homeDirectory;
+    }
+
+    public String getTempDirectory()
+    {
+        return tempDirectory;
+    }
+
+    @Config("duckdb.temp-directory")
+    public void setTempDirectory(String tempDirectory)
+    {
+        this.tempDirectory = tempDirectory;
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/client/duckdb/DuckDBConfig.java
+++ b/accio-base/src/main/java/io/accio/base/client/duckdb/DuckDBConfig.java
@@ -15,20 +15,21 @@
 package io.accio.base.client.duckdb;
 
 import io.airlift.configuration.Config;
+import io.airlift.units.DataSize;
 
 public class DuckDBConfig
 {
-    private String memoryLimit = Runtime.getRuntime().maxMemory() / 2 + "B";
-    private String homeDirectory = "/tmp/duckdb";
+    private DataSize memoryLimit = DataSize.of(Runtime.getRuntime().maxMemory() / 2, DataSize.Unit.BYTE);
+    private String homeDirectory;
     private String tempDirectory = "/tmp/duck";
 
-    public String getMemoryLimit()
+    public DataSize getMemoryLimit()
     {
         return memoryLimit;
     }
 
     @Config("duckdb.memory-limit")
-    public void setMemoryLimit(String memoryLimit)
+    public void setMemoryLimit(DataSize memoryLimit)
     {
         this.memoryLimit = memoryLimit;
     }

--- a/accio-base/src/main/java/io/accio/base/client/duckdb/DuckdbClient.java
+++ b/accio-base/src/main/java/io/accio/base/client/duckdb/DuckdbClient.java
@@ -66,7 +66,7 @@ public final class DuckdbClient
 
     private void init()
     {
-        DataSize memoryLimit = DataSize.valueOf(duckDBConfig.getMemoryLimit());
+        DataSize memoryLimit = duckDBConfig.getMemoryLimit();
         executeDDL(format("SET memory_limit='%s'", memoryLimit.toBytesValueString()));
         LOG.info("Set memory limit to %s", memoryLimit.toBytesValueString());
         executeDDL(format("SET temp_directory='%s'", duckDBConfig.getTempDirectory()));

--- a/accio-cache/src/main/java/io/accio/cache/CacheManager.java
+++ b/accio-cache/src/main/java/io/accio/cache/CacheManager.java
@@ -50,6 +50,7 @@ import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.accio.base.CatalogSchemaTableName.catalogSchemaTableName;
+import static io.accio.base.metadata.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.accio.base.metadata.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.accio.cache.EventLogger.Level.ERROR;
 import static io.accio.cache.EventLogger.Level.INFO;
@@ -338,10 +339,15 @@ public class CacheManager
     }
 
     public List<Object> getDuckDBSettings()
-            throws SQLException
     {
-        ConnectorRecordIterator iter = query("SELECT * FROM duckdb_settings()", List.of());
-        return ImmutableList.copyOf(iter);
+        try {
+            ConnectorRecordIterator iter = query("SELECT * FROM duckdb_settings()", List.of());
+            return ImmutableList.copyOf(iter);
+        }
+        catch (Exception e) {
+            LOG.error(e, "Failed to get duckdb settings");
+            throw new AccioException(GENERIC_INTERNAL_ERROR, e);
+        }
     }
 
     private class Task

--- a/accio-cache/src/main/java/io/accio/cache/CacheManager.java
+++ b/accio-cache/src/main/java/io/accio/cache/CacheManager.java
@@ -337,6 +337,13 @@ public class CacheManager
         Optional.ofNullable(tasks.get(name)).ifPresent(Task::waitUntilDone);
     }
 
+    public List<Object> getDuckDBSettings()
+            throws SQLException
+    {
+        ConnectorRecordIterator iter = query("SELECT * FROM duckdb_settings()", List.of());
+        return ImmutableList.copyOf(iter);
+    }
+
     private class Task
     {
         private final TaskInfo taskInfo;

--- a/accio-cache/src/main/java/io/accio/cache/CacheModule.java
+++ b/accio-cache/src/main/java/io/accio/cache/CacheModule.java
@@ -16,6 +16,7 @@ package io.accio.cache;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
+import io.accio.base.client.duckdb.DuckDBConfig;
 import io.accio.base.client.duckdb.DuckdbClient;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 
@@ -28,6 +29,7 @@ public class CacheModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(DuckdbS3StyleStorageConfig.class);
+        configBinder(binder).bindConfig(DuckDBConfig.class);
         binder.bind(CacheStorageConfig.class).to(DuckdbS3StyleStorageConfig.class).in(Scopes.SINGLETON);
         binder.bind(CacheManager.class).in(Scopes.SINGLETON);
         binder.bind(EventLogger.class).to(Log4jEventLogger.class).in(Scopes.SINGLETON);

--- a/accio-main/src/main/java/io/accio/main/web/CacheResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/CacheResource.java
@@ -99,7 +99,7 @@ public class CacheResource
             asyncResponse.resume(Response.ok(cacheManager.getDuckDBSettings()).build());
         }
         catch (Exception e) {
-            asyncResponse.resume(Response.serverError().build());
+            asyncResponse.resume(asyncResponse.resume(e));
         }
     }
 }

--- a/accio-main/src/main/java/io/accio/main/web/CacheResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/CacheResource.java
@@ -95,11 +95,6 @@ public class CacheResource
     @Path("duckdb/settings")
     public void getDuckDBSettings(@Suspended AsyncResponse asyncResponse)
     {
-        try {
-            asyncResponse.resume(Response.ok(cacheManager.getDuckDBSettings()).build());
-        }
-        catch (Exception e) {
-            asyncResponse.resume(asyncResponse.resume(e));
-        }
+        asyncResponse.resume(Response.ok(cacheManager.getDuckDBSettings()).build());
     }
 }

--- a/accio-main/src/main/java/io/accio/main/web/CacheResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/CacheResource.java
@@ -90,4 +90,16 @@ public class CacheResource
                 .listTaskInfo(catalogName, schemaName)
                 .whenComplete(bindAsyncResponse(asyncResponse));
     }
+
+    @GET
+    @Path("duckdb/settings")
+    public void getDuckDBSettings(@Suspended AsyncResponse asyncResponse)
+    {
+        try {
+            asyncResponse.resume(Response.ok(cacheManager.getDuckDBSettings()).build());
+        }
+        catch (Exception e) {
+            asyncResponse.resume(Response.serverError().build());
+        }
+    }
 }

--- a/accio-testing/src/main/java/io/accio/testing/AbstractTestFramework.java
+++ b/accio-testing/src/main/java/io/accio/testing/AbstractTestFramework.java
@@ -17,6 +17,7 @@ package io.accio.testing;
 import com.google.common.collect.ImmutableList;
 import io.accio.base.SessionContext;
 import io.accio.base.client.AutoCloseableIterator;
+import io.accio.base.client.duckdb.DuckDBConfig;
 import io.accio.base.client.duckdb.DuckdbClient;
 import io.accio.base.dto.Column;
 import io.accio.base.dto.Manifest;
@@ -64,7 +65,7 @@ public abstract class AbstractTestFramework
     @BeforeClass
     public void init()
     {
-        duckdbClient = new DuckdbClient();
+        duckdbClient = new DuckdbClient(new DuckDBConfig());
         prepareData();
     }
 

--- a/accio-validation/src/test/java/io/accio/TestMetricValidation.java
+++ b/accio-validation/src/test/java/io/accio/TestMetricValidation.java
@@ -17,6 +17,7 @@ package io.accio;
 import io.accio.base.AccioMDL;
 import io.accio.base.AccioTypes;
 import io.accio.base.client.Client;
+import io.accio.base.client.duckdb.DuckDBConfig;
 import io.accio.base.client.duckdb.DuckdbClient;
 import io.accio.base.dto.Column;
 import io.accio.base.dto.EnumDefinition;
@@ -50,7 +51,7 @@ public class TestMetricValidation
 
     public TestMetricValidation()
     {
-        client = new DuckdbClient();
+        client = new DuckdbClient(new DuckDBConfig());
         sample = AccioMDL.fromManifest(withDefaultCatalogSchema()
                 .setModels(List.of(
                         Model.model("Flight",


### PR DESCRIPTION
# Description
There're 3 configurations exposed by this PR:
- `duckdb.memory-limit`: To set `memory_limit` in DuckDB. The default value is `the runtime max heap size / 2`
- `duckdb.home-directory`: To set `home-directory` in DuckDB.
  - This config is disable because the known issue: https://github.com/duckdb/duckdb/issues/10062
-  `duckdb.temp-directory`: To set `temp-driectory` in DuckDB.