### PR TITLE
Avoid to get the null exception when cache rewriting

### DIFF
--- a/accio-cache/src/main/java/io/accio/cache/DefaultCachedTableMapping.java
+++ b/accio-cache/src/main/java/io/accio/cache/DefaultCachedTableMapping.java
@@ -77,7 +77,8 @@ public class DefaultCachedTableMapping
     @Override
     public Optional<String> convertToCachedTable(CatalogSchemaTableName catalogSchemaTableName)
     {
-        return cachedTableMapping.get(catalogSchemaTableName).getTableName();
+        return Optional.ofNullable(cachedTableMapping.get(catalogSchemaTableName))
+                .flatMap(CacheInfoPair::getTableName);
     }
 
     @Override


### PR DESCRIPTION
We may occur null exception if the specific table isn't exist in table mapping. Add an Optional to avoid the null exception.