### PR TITLE
Fix error with dynamic calculated expression with non-calculated field in same model

### DIFF
--- a/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/AccioDataLineage.java
+++ b/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/AccioDataLineage.java
@@ -268,8 +268,9 @@ public class AccioDataLineage
                         Relationship relationship = info.getRelationships().get(i);
                         String left = relationship.getModels().get(0);
                         String right = relationship.getModels().get(1);
-                        String leftKey = getJoinKey(parseExpression(relationship.getCondition()), left).orElseThrow();
-                        String rightKey = getJoinKey(parseExpression(relationship.getCondition()), right).orElseThrow();
+                        Expression joinCondition = parseExpression(relationship.getCondition());
+                        String leftKey = getJoinKey(joinCondition, left).orElseThrow();
+                        String rightKey = getJoinKey(joinCondition, right).orElseThrow();
                         sourceColumns.put(left, leftKey);
                         sourceColumns.put(right, rightKey);
                     }

--- a/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/AccioSqlRewrite.java
+++ b/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/AccioSqlRewrite.java
@@ -46,6 +46,8 @@ import java.util.stream.Stream;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.accio.base.Utils.checkArgument;
+import static io.accio.sqlrewrite.AccioDataLineage.getColumn;
+import static io.accio.sqlrewrite.AccioDataLineage.getModel;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -66,7 +68,15 @@ public class AccioSqlRewrite
                                 .collect(toImmutableList()))
                 .flatMap(List::stream)
                 .collect(toImmutableList());
-        return dataLineage.getRequiredFields(collectedColumns);
+
+        LinkedHashMap<String, Set<String>> requiredFields = dataLineage.getRequiredFields(collectedColumns);
+        collectedColumns.forEach(columnName -> {
+            Set<String> columnNames = requiredFields.get(getModel(columnName));
+            columnNames.add(getColumn(columnName));
+            requiredFields.put(getModel(columnName), columnNames);
+        });
+
+        return requiredFields;
     }
 
     @Override

--- a/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestModel.java
+++ b/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestModel.java
@@ -14,6 +14,7 @@
 
 package io.accio.sqlrewrite;
 
+import com.google.common.collect.ImmutableList;
 import io.accio.base.AccioMDL;
 import io.accio.base.SessionContext;
 import io.accio.base.dto.Manifest;
@@ -34,6 +35,7 @@ import static io.accio.base.dto.Column.column;
 import static io.accio.base.dto.JoinType.MANY_TO_ONE;
 import static io.accio.base.dto.JoinType.ONE_TO_MANY;
 import static io.accio.base.dto.Model.model;
+import static io.accio.base.dto.Model.onBaseObject;
 import static io.accio.base.dto.Relationship.relationship;
 import static io.accio.sqlrewrite.AccioSqlRewrite.ACCIO_SQL_REWRITE;
 import static java.util.Objects.requireNonNull;
@@ -124,7 +126,8 @@ public class TestModel
                 column("orders", "Orders", "OrdersCustomer", true),
                 caluclatedColumn("totalprice", BIGINT, "sum(orders.totalprice)"),
                 caluclatedColumn("buy_item_count", BIGINT, "count(distinct orders.lineitem.orderkey_linenumber)"),
-                caluclatedColumn("lineitem_totalprice", BIGINT, "sum(orders.lineitem.discount * orders.lineitem.extendedprice)"));
+                caluclatedColumn("lineitem_totalprice", BIGINT, "sum(orders.lineitem.discount * orders.lineitem.extendedprice)"),
+                caluclatedColumn("test_col", BIGINT, "sum(orders.lineitem.discount * nationkey)"));
         Manifest manifest = withDefaultCatalogSchema()
                 .setModels(List.of(newCustomer, orders, lineitem))
                 .setRelationships(List.of(ordersCustomer, ordersLineitem))
@@ -144,6 +147,14 @@ public class TestModel
         assertQuery(mdl,
                 "SELECT custkey, lineitem_totalprice FROM Customer WHERE custkey = 370",
                 "SELECT c.custkey, sum(l.extendedprice * l.discount) FROM customer c " +
+                        "LEFT JOIN orders o ON c.custkey = o.custkey " +
+                        "LEFT JOIN lineitem l ON o.orderkey = l.orderkey " +
+                        "WHERE c.custkey = 370 " +
+                        "GROUP BY 1");
+
+        assertQuery(mdl,
+                "SELECT custkey, test_col FROM Customer WHERE custkey = 370",
+                "SELECT c.custkey, sum(l.discount * c.nationkey) FROM customer c " +
                         "LEFT JOIN orders o ON c.custkey = o.custkey " +
                         "LEFT JOIN lineitem l ON o.orderkey = l.orderkey " +
                         "WHERE c.custkey = 370 " +
@@ -217,6 +228,30 @@ public class TestModel
                 .doesNotThrowAnyException();
         assertThatCode(() -> query(rewrite("SELECT customer_name, total_price FROM Customer c LEFT JOIN Orders o ON c.custkey = o.custkey", mdl, true)))
                 .hasMessageMatching("found cycle in .*");
+    }
+
+    @Test
+    public void testModelOnModel()
+    {
+        Model newCustomer = addColumnsToModel(
+                customer,
+                column("orders", "Orders", "OrdersCustomer", true),
+                caluclatedColumn("totalprice", BIGINT, "sum(orders.totalprice)"));
+        Model onCustomer = onBaseObject(
+                "OnCustomer",
+                "Customer",
+                ImmutableList.of(
+                        column("mom_custkey", "VARCHAR", null, true, "custkey"),
+                        column("mom_totalprice", "VARCHAR", null, true, "totalprice")),
+                "mom_custkey");
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(newCustomer, onCustomer, orders))
+                .setRelationships(List.of(ordersCustomer))
+                .build();
+        AccioMDL mdl = AccioMDL.fromManifest(manifest);
+
+        assertThatCode(() -> query(rewrite("SELECT * FROM OnCustomer", mdl, true)))
+                .doesNotThrowAnyException();
     }
 
     private void assertQuery(AccioMDL mdl, @Language("SQL") String accioSql, @Language("SQL") String duckDBSql)

--- a/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestModel.java
+++ b/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestModel.java
@@ -250,8 +250,11 @@ public class TestModel
                 .build();
         AccioMDL mdl = AccioMDL.fromManifest(manifest);
 
-        assertThatCode(() -> query(rewrite("SELECT * FROM OnCustomer", mdl, true)))
-                .doesNotThrowAnyException();
+        assertQuery(mdl, "SELECT mom_custkey, mom_totalprice FROM OnCustomer WHERE mom_custkey = 370",
+                "SELECT c.custkey, sum(o.totalprice) FROM customer c\n" +
+                        "LEFT JOIN orders o ON c.custkey = o.custkey\n" +
+                        "WHERE c.custkey = 370\n" +
+                        "GROUP BY 1");
     }
 
     private void assertQuery(AccioMDL mdl, @Language("SQL") String accioSql, @Language("SQL") String duckDBSql)


### PR DESCRIPTION
- calculated fields that use relationship should also have joinkeys in required fields.
- remove field itself from required fields
- fix calculated field can't use non-calculated column in same model
- fix model on model lineage