### PR TITLE
Fix prepared statement parameter for BIgQuery

### DIFF
--- a/accio-base/src/main/java/io/accio/base/type/BaseTimestampType.java
+++ b/accio-base/src/main/java/io/accio/base/type/BaseTimestampType.java
@@ -59,11 +59,4 @@ abstract class BaseTimestampType
         long microSecondsSince2K = buffer.readLong();
         return PgDatetimeUtils.toTrinoTimestamp(microSecondsSince2K);
     }
-
-    @Override
-    public Object getEmptyValue()
-    {
-        // TODO: give more suitable empty value for time related types
-        return "";
-    }
 }

--- a/accio-base/src/main/java/io/accio/base/type/DateType.java
+++ b/accio-base/src/main/java/io/accio/base/type/DateType.java
@@ -99,7 +99,6 @@ public class DateType
     @Override
     public Object getEmptyValue()
     {
-        // TODO: give more suitable empty value for time related types
-        return "";
+        return "1970-01-01";
     }
 }

--- a/accio-base/src/main/java/io/accio/base/type/NumericType.java
+++ b/accio-base/src/main/java/io/accio/base/type/NumericType.java
@@ -182,7 +182,7 @@ public class NumericType
     @Override
     public BigDecimal decodeUTF8Text(byte[] bytes)
     {
-        throw new UnsupportedOperationException();
+        return new BigDecimal(new String(bytes, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/accio-base/src/main/java/io/accio/base/type/TimestampType.java
+++ b/accio-base/src/main/java/io/accio/base/type/TimestampType.java
@@ -89,4 +89,10 @@ public class TimestampType
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Object getEmptyValue()
+    {
+        return "1970-01-01 00:00:00";
+    }
 }

--- a/accio-base/src/main/java/io/accio/base/type/TimestampWithTimeZoneType.java
+++ b/accio-base/src/main/java/io/accio/base/type/TimestampWithTimeZoneType.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
-import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 
 public class TimestampWithTimeZoneType
@@ -89,14 +88,8 @@ public class TimestampWithTimeZoneType
     @VisibleForTesting
     ZonedDateTime tryParse(String timeString)
     {
-        try {
-            // Postgres TimestampTz format
-            return ZonedDateTime.parse(timeString, PG_TIMESTAMP);
-        }
-        catch (Exception e) {
-            // JDBC transform ZonedDateTime to String
-            return ZonedDateTime.parse(timeString, ISO_ZONED_DATE_TIME);
-        }
+        // Postgres TimestampTz format
+        return ZonedDateTime.parse(timeString, PG_TIMESTAMP);
     }
 
     @Override

--- a/accio-base/src/main/java/io/accio/base/type/TimestampWithTimeZoneType.java
+++ b/accio-base/src/main/java/io/accio/base/type/TimestampWithTimeZoneType.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 
 public class TimestampWithTimeZoneType
@@ -88,12 +89,25 @@ public class TimestampWithTimeZoneType
     @VisibleForTesting
     ZonedDateTime tryParse(String timeString)
     {
-        return ZonedDateTime.parse(timeString, PG_TIMESTAMP);
+        try {
+            // Postgres TimestampTz format
+            return ZonedDateTime.parse(timeString, PG_TIMESTAMP);
+        }
+        catch (Exception e) {
+            // JDBC transform ZonedDateTime to String
+            return ZonedDateTime.parse(timeString, ISO_ZONED_DATE_TIME);
+        }
     }
 
     @Override
     public int writeAsBinary(ByteBuf buffer, @Nonnull Object value)
     {
         throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Object getEmptyValue()
+    {
+        return "1970-01-01 00:00:00.000000+01:00";
     }
 }

--- a/accio-connector-client/src/main/java/io/accio/connector/bigquery/BigQueryType.java
+++ b/accio-connector-client/src/main/java/io/accio/connector/bigquery/BigQueryType.java
@@ -22,7 +22,6 @@ import io.accio.base.type.DateType;
 import io.accio.base.type.IntervalType;
 import io.accio.base.type.JsonType;
 import io.accio.base.type.NumericType;
-import io.accio.base.type.OidType;
 import io.accio.base.type.PGArray;
 import io.accio.base.type.PGType;
 import io.accio.base.type.PGTypes;
@@ -58,6 +57,7 @@ import static io.accio.base.type.ByteaType.BYTEA;
 import static io.accio.base.type.CharType.CHAR;
 import static io.accio.base.type.DoubleType.DOUBLE;
 import static io.accio.base.type.IntegerType.INTEGER;
+import static io.accio.base.type.OidType.OID_INSTANCE;
 import static io.accio.base.type.PGTypes.toPgRecordArray;
 import static io.accio.base.type.RealType.REAL;
 import static io.accio.base.type.RecordType.EMPTY_RECORD;
@@ -96,7 +96,7 @@ public final class BigQueryType
                 .put(INTEGER, INT64)
                 .put(SMALLINT, INT64)
                 .put(TINYINT, INT64)
-                .put(OidType.OID_INSTANCE, INT64)
+                .put(OID_INSTANCE, INT64)
                 .put(CHAR, STRING)
                 .put(VARCHAR, STRING)
                 .put(TEXT, STRING)

--- a/accio-connector-client/src/main/java/io/accio/connector/bigquery/BigQueryType.java
+++ b/accio-connector-client/src/main/java/io/accio/connector/bigquery/BigQueryType.java
@@ -22,6 +22,7 @@ import io.accio.base.type.DateType;
 import io.accio.base.type.IntervalType;
 import io.accio.base.type.JsonType;
 import io.accio.base.type.NumericType;
+import io.accio.base.type.OidType;
 import io.accio.base.type.PGArray;
 import io.accio.base.type.PGType;
 import io.accio.base.type.PGTypes;
@@ -95,6 +96,7 @@ public final class BigQueryType
                 .put(INTEGER, INT64)
                 .put(SMALLINT, INT64)
                 .put(TINYINT, INT64)
+                .put(OidType.OID_INSTANCE, INT64)
                 .put(CHAR, STRING)
                 .put(VARCHAR, STRING)
                 .put(TEXT, STRING)

--- a/accio-tests/src/main/java/io/accio/testing/TestingWireProtocolClient.java
+++ b/accio-tests/src/main/java/io/accio/testing/TestingWireProtocolClient.java
@@ -36,6 +36,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -45,6 +46,7 @@ import static io.accio.base.type.DateType.DATE;
 import static io.accio.base.type.InetType.INET;
 import static io.accio.base.type.IntegerType.INTEGER;
 import static io.accio.base.type.TimestampType.TIMESTAMP;
+import static io.accio.base.type.TimestampWithTimeZoneType.PG_TIMESTAMP;
 import static io.accio.base.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIMEZONE;
 import static io.accio.main.wireprotocol.FormatCodes.FormatCode.BINARY;
 import static io.accio.main.wireprotocol.FormatCodes.FormatCode.TEXT;
@@ -1146,6 +1148,9 @@ public class TestingWireProtocolClient
                     stringBuilder.setLength(stringBuilder.length() - 1);
                     stringBuilder.append("}");
                     return stringBuilder.toString().getBytes(UTF_8);
+                }
+                else if (type.equals(TIMESTAMP_WITH_TIMEZONE)) {
+                    return PG_TIMESTAMP.format((ZonedDateTime) value).getBytes(UTF_8);
                 }
                 return value.toString().getBytes(UTF_8);
             }

--- a/accio-tests/src/main/java/io/accio/testing/TestingWireProtocolClient.java
+++ b/accio-tests/src/main/java/io/accio/testing/TestingWireProtocolClient.java
@@ -16,6 +16,8 @@ package io.accio.testing;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
+import io.accio.base.type.ByteaType;
+import io.accio.base.type.PGArray;
 import io.accio.base.type.PGType;
 import io.accio.base.type.PGTypes;
 import io.accio.base.type.UuidType;
@@ -1129,6 +1131,22 @@ public class TestingWireProtocolClient
         public byte[] getFormattedBytes()
         {
             if (formatCode == TEXT) {
+                if (type instanceof PGArray) {
+                    StringBuilder stringBuilder = new StringBuilder();
+                    stringBuilder.append("{");
+                    for (Object element : (Object[]) value) {
+                        if (element == null) {
+                            stringBuilder.append("NULL");
+                        }
+                        else {
+                            stringBuilder.append(element);
+                        }
+                        stringBuilder.append(',');
+                    }
+                    stringBuilder.setLength(stringBuilder.length() - 1);
+                    stringBuilder.append("}");
+                    return stringBuilder.toString().getBytes(UTF_8);
+                }
                 return value.toString().getBytes(UTF_8);
             }
             return getBinary();
@@ -1142,6 +1160,9 @@ public class TestingWireProtocolClient
                 buffer.putLong(uuid.getMostSignificantBits());
                 buffer.putLong(uuid.getLeastSignificantBits());
                 return buffer.array();
+            }
+            else if (type.equals(ByteaType.BYTEA)) {
+                return (byte[]) value;
             }
             throw new RuntimeException("Unsupported write binary type: " + type);
         }


### PR DESCRIPTION
- Support more type parameter passed by native protocol.
  - `numeric`, `date`, `timestamp`, `timestamptz`, `bytea`, `interval`, `array`.