### PR TITLE
Implement Lineage Analysis API

### DIFF
--- a/accio-main/src/main/java/io/accio/main/web/LineageResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/LineageResource.java
@@ -15,6 +15,8 @@
 package io.accio.main.web;
 
 import io.accio.base.AccioMDL;
+import io.accio.base.dto.Column;
+import io.accio.base.dto.CumulativeMetric;
 import io.accio.main.AccioMetastore;
 import io.accio.main.web.dto.ColumnLineageInputDto;
 import io.accio.main.web.dto.LineageResult;
@@ -82,15 +84,42 @@ public class LineageResource
                             .stream()
                             .map(entry -> new LineageResult(
                                     entry.getKey(),
-                                    entry.getValue().stream().map(column -> {
-                                        String type = mdl.getColumn(QualifiedName.of(entry.getKey(), column))
-                                                .orElseThrow(() -> new RuntimeException("Cannot find column " + column + " in model " + entry.getKey()))
-                                                .getType();
-                                        return new LineageResult.Column(column, Map.of("type", type));
-                                    }).collect(toList())))
+                                    entry.getValue().stream().map(column ->
+                                            new LineageResult.Column(column, Map.of("type", getColumnType(mdl, entry.getKey(), column)))).collect(toList())))
                             .collect(Collectors.toList());
                 })
                 .whenComplete(bindAsyncResponse(asyncResponse));
+    }
+
+    private String getColumnType(AccioMDL mdl, String objectName, String columnName)
+    {
+        if (!mdl.isObjectExist(objectName)) {
+            throw new IllegalArgumentException("Dataset " + objectName + " not found");
+        }
+        if (mdl.getModel(objectName).isPresent()) {
+            return mdl.getModel(objectName).get().getColumns().stream()
+                    .filter(column -> columnName.equals(column.getName()))
+                    .map(Column::getType)
+                    .findAny()
+                    .orElseThrow(() -> new IllegalArgumentException("Column " + columnName + " not found in " + objectName));
+        }
+        else if (mdl.getMetric(objectName).isPresent()) {
+            return mdl.getMetric(objectName).get().getColumns().stream()
+                    .filter(column -> columnName.equals(column.getName()))
+                    .map(Column::getType)
+                    .findAny()
+                    .orElseThrow(() -> new IllegalArgumentException("Column " + columnName + " not found in " + objectName));
+        }
+        else if (mdl.getCumulativeMetric(objectName).isPresent()) {
+            CumulativeMetric cumulativeMetric = mdl.getCumulativeMetric(objectName).get();
+            if (cumulativeMetric.getMeasure().getName().equals(columnName)) {
+                return cumulativeMetric.getMeasure().getType();
+            }
+            if (cumulativeMetric.getWindow().getName().equals(columnName)) {
+                return getColumnType(mdl, cumulativeMetric.getBaseObject(), cumulativeMetric.getWindow().getRefColumn());
+            }
+        }
+        throw new IllegalArgumentException("Dataset " + objectName + " is not a model, metric or cumulative metric");
     }
 
     @GET

--- a/accio-main/src/main/java/io/accio/main/web/LineageResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/LineageResource.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.accio.main.web;
+
+import io.accio.base.AccioMDL;
+import io.accio.main.AccioMetastore;
+import io.accio.main.web.dto.ColumnLineageInputDto;
+import io.accio.main.web.dto.LineageResult;
+import io.accio.main.web.dto.SqlLineageInputDto;
+import io.accio.sqlrewrite.AccioDataLineage;
+import io.trino.sql.tree.QualifiedName;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static io.accio.base.Utils.checkArgument;
+import static io.accio.main.web.AccioExceptionMapper.bindAsyncResponse;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/v1/lineage")
+public class LineageResource
+{
+    private final AccioMetastore accioMetastore;
+
+    @Inject
+    public LineageResource(
+            AccioMetastore accioMetastore)
+    {
+        this.accioMetastore = requireNonNull(accioMetastore, "accioMetastore is null");
+    }
+
+    @GET
+    @Path("/column")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public void getColumnLineage(
+            ColumnLineageInputDto inputDto,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        CompletableFuture
+                .supplyAsync(() -> {
+                    AccioDataLineage lineage;
+                    AccioMDL mdl;
+                    if (inputDto.getManifest() == null) {
+                        lineage = accioMetastore.getAccioDataLineage();
+                        mdl = accioMetastore.getAccioMDL();
+                    }
+                    else {
+                        mdl = AccioMDL.fromManifest(inputDto.getManifest());
+                        lineage = AccioDataLineage.analyze(mdl);
+                    }
+                    checkArgument(inputDto.getModelName() != null && !inputDto.getModelName().isEmpty(),
+                            "modelName must be specified");
+                    checkArgument(inputDto.getColumnName() != null && !inputDto.getColumnName().isEmpty(),
+                            "columnName must be specified");
+                    return lineage.getRequiredFields(List.of(QualifiedName.of(inputDto.getModelName(), inputDto.getColumnName())))
+                            .entrySet()
+                            .stream()
+                            .map(entry -> new LineageResult(
+                                    entry.getKey(),
+                                    entry.getValue().stream().map(column -> {
+                                        String type = mdl.getColumn(QualifiedName.of(entry.getKey(), column))
+                                                .orElseThrow(() -> new RuntimeException("Cannot find column " + column + " in model " + entry.getKey()))
+                                                .getType();
+                                        return new LineageResult.Column(column, Map.of("type", type));
+                                    }).collect(toList())))
+                            .collect(Collectors.toList());
+                })
+                .whenComplete(bindAsyncResponse(asyncResponse));
+    }
+
+    @GET
+    @Path("sql")
+    public void getSqlLineage(
+            SqlLineageInputDto inputDto,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        // TODO: wait sql lineage implemented
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/web/dto/ColumnLineageInputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/ColumnLineageInputDto.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.accio.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.accio.base.dto.Manifest;
+
+public class ColumnLineageInputDto
+{
+    private final Manifest manifest;
+    private final String modelName;
+    private final String columnName;
+
+    @JsonCreator
+    public ColumnLineageInputDto(
+            @JsonProperty("manifest") Manifest manifest,
+            @JsonProperty("modelName") String modelName,
+            @JsonProperty("columnName") String columnName)
+    {
+        this.manifest = manifest;
+        this.modelName = modelName;
+        this.columnName = columnName;
+    }
+
+    @JsonProperty
+    public Manifest getManifest()
+    {
+        return manifest;
+    }
+
+    @JsonProperty
+    public String getModelName()
+    {
+        return modelName;
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/web/dto/LineageResult.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/LineageResult.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.accio.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class LineageResult
+{
+    public static LineageResult lineageResult(String datasetName, List<Column> columns)
+    {
+        return new LineageResult(datasetName, columns);
+    }
+
+    public static Column columnWithType(String name, String type)
+    {
+        return new Column(name, ImmutableMap.of("type", type));
+    }
+
+    private final String datasetName;
+    private final List<Column> columns;
+
+    @JsonCreator
+    public LineageResult(
+            @JsonProperty("datasetName") String datasetName,
+            @JsonProperty("columns") List<Column> columns)
+    {
+        this.datasetName = datasetName;
+        this.columns = columns;
+    }
+
+    @JsonProperty
+    public String getDatasetName()
+    {
+        return datasetName;
+    }
+
+    @JsonProperty
+    public List<Column> getColumns()
+    {
+        return columns;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LineageResult that = (LineageResult) o;
+        return Objects.equals(datasetName, that.datasetName) && Objects.equals(columns, that.columns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(datasetName, columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LineageResult{" +
+                "datasetName='" + datasetName + '\'' +
+                ", columns=" + columns +
+                '}';
+    }
+
+    public static class Column
+    {
+        private final String name;
+        private final Map<String, String> properties;
+
+        @JsonCreator
+        public Column(
+                @JsonProperty("name") String name,
+                @JsonProperty("properties") Map<String, String> properties)
+        {
+            this.name = name;
+            this.properties = properties;
+        }
+
+        @JsonProperty
+        public String getName()
+        {
+            return name;
+        }
+
+        @JsonProperty
+        public Map<String, String> getProperties()
+        {
+            return properties;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Column column = (Column) o;
+            return Objects.equals(name, column.name) && Objects.equals(properties, column.properties);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, properties);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Column{" +
+                    "name='" + name + '\'' +
+                    ", properties=" + properties +
+                    '}';
+        }
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/web/dto/SqlLineageInputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/SqlLineageInputDto.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.accio.base.dto.Manifest;
+
+public class SqlLineageInputDto
+{
+    private final Manifest manifest;
+    private final String sql;
+
+    @JsonCreator
+    public SqlLineageInputDto(
+            @JsonProperty("manifest") Manifest manifest,
+            @JsonProperty("sql") String sql)
+    {
+        this.manifest = manifest;
+        this.sql = sql;
+    }
+
+    @JsonProperty
+    public Manifest getManifest()
+    {
+        return manifest;
+    }
+
+    @JsonProperty
+    public String getSql()
+    {
+        return sql;
+    }
+}

--- a/accio-server/src/main/java/io/accio/server/module/WebModule.java
+++ b/accio-server/src/main/java/io/accio/server/module/WebModule.java
@@ -20,6 +20,7 @@ import io.accio.main.PreviewService;
 import io.accio.main.pgcatalog.PgCatalogManager;
 import io.accio.main.web.AccioExceptionMapper;
 import io.accio.main.web.CacheResource;
+import io.accio.main.web.LineageResource;
 import io.accio.main.web.MDLResource;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 
@@ -32,6 +33,7 @@ public class WebModule
     protected void setup(Binder binder)
     {
         jaxrsBinder(binder).bind(MDLResource.class);
+        jaxrsBinder(binder).bind(LineageResource.class);
         jaxrsBinder(binder).bind(CacheResource.class);
         jaxrsBinder(binder).bindInstance(new AccioExceptionMapper());
         binder.bind(PreviewService.class).in(Scopes.SINGLETON);

--- a/accio-tests/src/test/java/io/accio/testing/TestLineageResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestLineageResource.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.accio.base.dto.Manifest;
+import io.accio.base.dto.Metric;
+import io.accio.base.dto.Model;
+import io.accio.base.dto.Relationship;
+import io.accio.main.web.dto.ColumnLineageInputDto;
+import io.accio.main.web.dto.LineageResult;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.accio.base.AccioTypes.BIGINT;
+import static io.accio.base.AccioTypes.DATE;
+import static io.accio.base.AccioTypes.INTEGER;
+import static io.accio.base.AccioTypes.VARCHAR;
+import static io.accio.base.dto.Column.caluclatedColumn;
+import static io.accio.base.dto.Column.column;
+import static io.accio.base.dto.JoinType.MANY_TO_ONE;
+import static io.accio.base.dto.JoinType.ONE_TO_MANY;
+import static io.accio.base.dto.Manifest.MANIFEST_JSON_CODEC;
+import static io.accio.base.dto.Metric.metric;
+import static io.accio.base.dto.Model.model;
+import static io.accio.base.dto.Relationship.relationship;
+import static io.accio.main.web.dto.LineageResult.columnWithType;
+import static io.accio.main.web.dto.LineageResult.lineageResult;
+import static io.accio.testing.AbstractTestFramework.addColumnsToModel;
+import static io.accio.testing.AbstractTestFramework.withDefaultCatalogSchema;
+import static io.accio.testing.WebApplicationExceptionAssert.assertWebApplicationException;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLineageResource
+        extends RequireAccioServer
+{
+    private Model customer;
+    private Model orders;
+    private Model lineitem;
+    private Relationship ordersCustomer;
+    private Relationship ordersLineitem;
+
+    private Path mdlDir;
+
+    @Override
+    protected TestingAccioServer createAccioServer()
+    {
+        initData();
+        Model newCustomer = addColumnsToModel(
+                customer,
+                column("orders", "Orders", "OrdersCustomer", true),
+                caluclatedColumn("lineitem_price", BIGINT, "sum(orders.lineitem.discount * orders.lineitem.extendedprice)"));
+        Model newOrders = addColumnsToModel(
+                orders,
+                column("customer", "Customer", "OrdersCustomer", true),
+                column("lineitem", "Lineitem", "OrdersLineitem", true));
+        Model newLineitem = addColumnsToModel(
+                lineitem,
+                column("orders", "Orders", "OrdersLineitem", true));
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(newCustomer, newOrders, newLineitem))
+                .setRelationships(List.of(ordersCustomer, ordersLineitem))
+                .build();
+        try {
+            mdlDir = Files.createTempDirectory("acciomdls");
+            Path accioMDLFilePath = mdlDir.resolve("acciomdl.json");
+            Files.write(accioMDLFilePath, MANIFEST_JSON_CODEC.toJsonBytes(manifest));
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("accio.directory", mdlDir.toAbsolutePath().toString())
+                .put("accio.datasource.type", "duckdb");
+
+        return TestingAccioServer.builder()
+                .setRequiredConfigs(properties.build())
+                .build();
+    }
+
+    private void initData()
+    {
+        customer = model("Customer",
+                "select * from main.customer",
+                List.of(
+                        column("custkey", INTEGER, null, true),
+                        column("name", VARCHAR, null, true),
+                        column("address", VARCHAR, null, true),
+                        column("nationkey", INTEGER, null, true),
+                        column("phone", VARCHAR, null, true),
+                        column("acctbal", INTEGER, null, true),
+                        column("mktsegment", VARCHAR, null, true),
+                        column("comment", VARCHAR, null, true)),
+                "custkey");
+        orders = model("Orders",
+                "select * from main.orders",
+                List.of(
+                        column("orderkey", INTEGER, null, true),
+                        column("custkey", INTEGER, null, true),
+                        column("orderstatus", VARCHAR, null, true),
+                        column("totalprice", INTEGER, null, true),
+                        column("orderdate", DATE, null, true),
+                        column("orderpriority", VARCHAR, null, true),
+                        column("clerk", VARCHAR, null, true),
+                        column("shippriority", INTEGER, null, true),
+                        column("comment", VARCHAR, null, true),
+                        column("lineitem", "Lineitem", "OrdersLineitem", true)),
+                "orderkey");
+        lineitem = model("Lineitem",
+                "select * from main.lineitem",
+                List.of(
+                        column("orderkey", INTEGER, null, true),
+                        column("partkey", INTEGER, null, true),
+                        column("suppkey", INTEGER, null, true),
+                        column("linenumber", INTEGER, null, true),
+                        column("quantity", INTEGER, null, true),
+                        column("extendedprice", INTEGER, null, true),
+                        column("discount", INTEGER, null, true),
+                        column("tax", INTEGER, null, true),
+                        column("returnflag", VARCHAR, null, true),
+                        column("linestatus", VARCHAR, null, true),
+                        column("shipdate", DATE, null, true),
+                        column("commitdate", DATE, null, true),
+                        column("receiptdate", DATE, null, true),
+                        column("shipinstruct", VARCHAR, null, true),
+                        column("shipmode", VARCHAR, null, true),
+                        column("comment", VARCHAR, null, true),
+                        column("orderkey_linenumber", VARCHAR, null, true, "concat(orderkey, '-', linenumber)")),
+                "orderkey_linenumber");
+        ordersCustomer = relationship("OrdersCustomer", List.of("Orders", "Customer"), MANY_TO_ONE, "Orders.custkey = Customer.custkey");
+        ordersLineitem = relationship("OrdersLineitem", List.of("Orders", "Lineitem"), ONE_TO_MANY, "Orders.orderkey = Lineitem.orderkey");
+    }
+
+    @Test
+    public void testColumnLineageDefaultManifest()
+    {
+        List<LineageResult> results = getColumnLineage(new ColumnLineageInputDto(null, "Customer", "lineitem_price"));
+        assertThat(results.size()).isEqualTo(3);
+
+        List<LineageResult> expected = ImmutableList.<LineageResult>builder()
+                .add(lineageResult("Customer", List.of(columnWithType("custkey", INTEGER), columnWithType("lineitem_price", BIGINT))))
+                .add(lineageResult("Orders", List.of(columnWithType("orderkey", INTEGER), columnWithType("custkey", INTEGER))))
+                .add(lineageResult("Lineitem", List.of(columnWithType("orderkey", INTEGER), columnWithType("extendedprice", INTEGER), columnWithType("discount", INTEGER))))
+                .build();
+
+        assertIgnoreOrder(results, expected);
+    }
+
+    @Test
+    public void testColumnLineageCustomManifest()
+    {
+        Model newCustomer = addColumnsToModel(
+                customer,
+                column("orders", "Orders", "OrdersCustomer", true),
+                caluclatedColumn("sum_lineitem_price", BIGINT, "sum(orders.lineitem.extendedprice)"));
+        Model newOrders = addColumnsToModel(
+                orders,
+                column("customer", "Customer", "OrdersCustomer", true),
+                column("lineitem", "Lineitem", "OrdersLineitem", true));
+        Model newLineitem = addColumnsToModel(
+                lineitem,
+                column("orders", "Orders", "OrdersLineitem", true));
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(newCustomer, newOrders, newLineitem))
+                .setRelationships(List.of(ordersCustomer, ordersLineitem))
+                .build();
+
+        List<LineageResult> results = getColumnLineage(new ColumnLineageInputDto(manifest, "Customer", "sum_lineitem_price"));
+        assertThat(results.size()).isEqualTo(3);
+
+        List<LineageResult> expected = ImmutableList.<LineageResult>builder()
+                .add(lineageResult("Customer", List.of(columnWithType("custkey", INTEGER), columnWithType("sum_lineitem_price", BIGINT))))
+                .add(lineageResult("Orders", List.of(columnWithType("orderkey", INTEGER), columnWithType("custkey", INTEGER))))
+                .add(lineageResult("Lineitem", List.of(columnWithType("orderkey", INTEGER), columnWithType("extendedprice", INTEGER))))
+                .build();
+
+        assertIgnoreOrder(results, expected);
+    }
+
+    @Test
+    public void testMetricOnModel()
+    {
+        Model newCustomer = addColumnsToModel(
+                customer,
+                column("orders", "Orders", "OrdersCustomer", true));
+        Metric customerSpending = metric("CustomerSpending", "Customer",
+                List.of(column("name", VARCHAR, null, true)),
+                List.of(column("spending", BIGINT, null, true, "sum(orders.totalprice)"),
+                        column("count", BIGINT, null, true, "count(*)")));
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(orders, newCustomer))
+                .setMetrics(List.of(customerSpending))
+                .setRelationships(List.of(ordersCustomer))
+                .build();
+
+        List<LineageResult> results = getColumnLineage(new ColumnLineageInputDto(manifest, "CustomerSpending", "spending"));
+        assertThat(results.size()).isEqualTo(3);
+
+        List<LineageResult> expected = ImmutableList.<LineageResult>builder()
+                .add(lineageResult("Customer", List.of(columnWithType("custkey", INTEGER))))
+                .add(lineageResult("CustomerSpending", List.of(columnWithType("spending", BIGINT))))
+                .add(lineageResult("Orders", List.of(columnWithType("custkey", INTEGER), columnWithType("totalprice", INTEGER))))
+                .build();
+
+        assertIgnoreOrder(results, expected);
+    }
+
+    @Test
+    public void testErrorHandling()
+    {
+        assertWebApplicationException(() -> getColumnLineage(new ColumnLineageInputDto(null, null, "lineitem_price")))
+                .hasErrorMessageMatches(".*modelName must be specified.*");
+        assertWebApplicationException(() -> getColumnLineage(new ColumnLineageInputDto(null, "Customer", null)))
+                .hasErrorMessageMatches(".*columnName must be specified.*");
+    }
+
+    private void assertIgnoreOrder(List<LineageResult> results, List<LineageResult> expecteds)
+    {
+        Map<String, Set<?>> resultMap = results.stream().collect(toMap(LineageResult::getDatasetName, m -> new HashSet(m.getColumns())));
+        expecteds.forEach(expected -> {
+            assertThat(resultMap.containsKey(expected.getDatasetName())).isTrue();
+            assertThat(resultMap.get(expected.getDatasetName())).isEqualTo(new HashSet(expected.getColumns()));
+        });
+    }
+}


### PR DESCRIPTION
follow up #421 
# Description
This PR implement the APIs for lineage analysis. Now, we has one for MDL column lineage. We will present another to analyze the column lineage used by a SQL soon.
## Changed
## Column Lineage API
Analyze a lineage for a column expression. User can append a manifest runtime or use the deployed manifest in default.
### URL
```
GET /v1/lineage/column
```
### Input
```
{
  "manifest": { ... },
  "datasetName": "Customer",
  "columnName": "revenue"
}
```
### Output
```
[
	{
		"name": "Orders"
	},
        {
		"name": "Lineitem",
		"columns": [
			{
				"name": "extendedprice",
				"properties": { "type": "REAL" }
			},
			{
				"name": "discount",
				"properties": { "type": "REAL" }
			},
		]
	}
]
```