### PR TITLE
Fix interval type test

### DIFF
--- a/accio-main/src/main/java/io/accio/main/AccioManager.java
+++ b/accio-main/src/main/java/io/accio/main/AccioManager.java
@@ -70,7 +70,7 @@ public class AccioManager
             deployAccioMDLFromFile();
         }
         else {
-            LOG.warn("No AccioMDL file found. AccioMDL will not be deployed.");
+            LOG.warn("No AccioMDL file found. AccioMDL will not be deployed, and no pg table will be generated.");
         }
     }
 

--- a/accio-main/src/main/java/io/accio/main/pgcatalog/function/PgFunctions.java
+++ b/accio-main/src/main/java/io/accio/main/pgcatalog/function/PgFunctions.java
@@ -51,7 +51,8 @@ public final class PgFunctions
     public static final PgFunction CURRENT_SCHEMAS = builder()
             .setName("current_schemas")
             .setLanguage(SQL)
-            .setDefinition("SELECT ARRAY(SELECT DISTINCT schema_name FROM INFORMATION_SCHEMA.SCHEMATA)")
+            // 'pg_catalog' is required since pg catalog schema might not be named with 'pg_catalog' due to config bigquery.metadata.schema.prefix
+            .setDefinition("SELECT ARRAY(SELECT DISTINCT schema_name FROM (SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA UNION ALL SELECT 'pg_catalog' AS schema_name))")
             .setArguments(ImmutableList.of(argument("include_implicit", BOOLEAN)))
             .setReturnType(VARCHAR_ARRAY)
             .build();


### PR DESCRIPTION
Currently TestBigQueryType.testInterval and TestWireProtocolTypeWithBigQuery>AbstractWireProtocolTypeTest.testInterval always fail. When the sql result contains PGInterval type, pg jdbc driver 42.3.1 will send a SQL as follows ([code reference](https://github.com/pgjdbc/pgjdbc/blob/3cf846e019767590cc1a4c1b90246ebc26bc5130/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java#L539-L550))
```sql
SELECT n.nspname = ANY(current_schemas(true)), n.nspname, t.typname 
FROM pg_catalog.pg_type t
JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = ?
```
and currently pg_type table always use `pg_catalog` to generate oid in column typnamespace while function current_schemas won't have any schema that named `pg_catalog` since every test suite use a random pgcatalog name.

We still need every pg table use `pg_catalog` to generate namespace oid since pg jdbc driver will directly address `... WHERE ... = 'pg_catalog'` in many SQLs. **So the solution in this pr is to add `pg_catalog` to current_schemas function.**

[Note]: I guess someone deleted `pg_catalog` dataset in bigquery recently, so the issue bumped out