### PR TITLE
Simple File-based Authentication

### DIFF
--- a/accio-main/src/main/java/io/accio/main/PostgresNettyProvider.java
+++ b/accio-main/src/main/java/io/accio/main/PostgresNettyProvider.java
@@ -21,6 +21,7 @@ import io.accio.cache.CachedTableMapping;
 import io.accio.main.metadata.Metadata;
 import io.accio.main.pgcatalog.regtype.RegObjectFactory;
 import io.accio.main.wireprotocol.PostgresNetty;
+import io.accio.main.wireprotocol.auth.Authentication;
 import io.accio.main.wireprotocol.ssl.SslContextProvider;
 import org.elasticsearch.common.network.NetworkService;
 
@@ -42,6 +43,7 @@ public class PostgresNettyProvider
     private final AccioMetastore accioMetastore;
     private final CacheManager cacheManager;
     private final CachedTableMapping cachedTableMapping;
+    private final Authentication authentication;
 
     @Inject
     public PostgresNettyProvider(
@@ -53,7 +55,8 @@ public class PostgresNettyProvider
             SqlConverter sqlConverter,
             AccioMetastore accioMetastore,
             CacheManager cacheManager,
-            CachedTableMapping cachedTableMapping)
+            CachedTableMapping cachedTableMapping,
+            Authentication authentication)
     {
         this.postgresWireProtocolConfig = requireNonNull(postgresWireProtocolConfig, "postgreWireProtocolConfig is null");
         this.accioConfig = requireNonNull(accioConfig, "accioConfig is null");
@@ -64,6 +67,7 @@ public class PostgresNettyProvider
         this.accioMetastore = requireNonNull(accioMetastore, "accioMetastore is null");
         this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
         this.cachedTableMapping = requireNonNull(cachedTableMapping, "cachedTableMapping is null");
+        this.authentication = requireNonNull(authentication, "authentication is null");
     }
 
     @Override
@@ -80,7 +84,8 @@ public class PostgresNettyProvider
                 sqlConverter,
                 accioMetastore,
                 cacheManager,
-                cachedTableMapping);
+                cachedTableMapping,
+                authentication);
         postgresNetty.start();
         return postgresNetty;
     }

--- a/accio-main/src/main/java/io/accio/main/PostgresWireProtocolConfig.java
+++ b/accio-main/src/main/java/io/accio/main/PostgresWireProtocolConfig.java
@@ -17,15 +17,16 @@ import io.airlift.configuration.Config;
 
 import javax.validation.constraints.NotNull;
 
+import java.io.File;
+
 public class PostgresWireProtocolConfig
 {
     public static final String PG_WIRE_PROTOCOL_PORT = "pg-wire-protocol.port";
-    public static final String PG_WIRE_PROTOCOL_SSL_ENABLED = "pg-wire-protocol.ssl.enabled";
-    public static final String PG_WIRE_PROTOCOL_NETTY_THREAD_COUNT = "pg-wire-protocol.netty.thread.count";
 
     private String port = "7432";
     private boolean sslEnable;
     private int nettyThreadCount;
+    private File authFile = new File("etc/accounts");
 
     @NotNull
     public String getPort()
@@ -46,7 +47,7 @@ public class PostgresWireProtocolConfig
         return sslEnable;
     }
 
-    @Config(PG_WIRE_PROTOCOL_SSL_ENABLED)
+    @Config("pg-wire-protocol.ssl.enabled")
     public PostgresWireProtocolConfig setSslEnable(boolean sslEnable)
     {
         this.sslEnable = sslEnable;
@@ -59,10 +60,22 @@ public class PostgresWireProtocolConfig
         return nettyThreadCount;
     }
 
-    @Config(PG_WIRE_PROTOCOL_NETTY_THREAD_COUNT)
+    @Config("pg-wire-protocol.netty.thread.count")
     public PostgresWireProtocolConfig setNettyThreadCount(int nettyThreadCount)
     {
         this.nettyThreadCount = nettyThreadCount;
+        return this;
+    }
+
+    public File getAuthFile()
+    {
+        return authFile;
+    }
+
+    @Config("pg-wire-protocol.auth.file")
+    public PostgresWireProtocolConfig setAuthFile(File authFile)
+    {
+        this.authFile = authFile;
         return this;
     }
 }

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresWireProtocol.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresWireProtocol.java
@@ -187,16 +187,13 @@ public class PostgresWireProtocol
 
     private void initAuthentication(Channel channel)
     {
-        finishAuthentication(channel, "");
-
-        // TODO: support auth
-        // Optional<String> password = wireProtocolSession.getPassword();
-        // if (password.isPresent()) {
-        //     finishAuthentication(channel, password.get());
-        // }
-        // else {
-        //     Messages.sendAuthenticationCleartextPassword(channel);
-        // }
+        Optional<String> password = wireProtocolSession.getPassword();
+        if (password.isPresent()) {
+            finishAuthentication(channel, password.get());
+        }
+        else {
+            Messages.sendAuthenticationCleartextPassword(channel);
+        }
     }
 
     private void handlePassword(ByteBuf buffer, final Channel channel)
@@ -209,8 +206,8 @@ public class PostgresWireProtocol
     {
         try {
             String clientUser = wireProtocolSession.getClientUser();
-            if (isNull(clientUser)) {
-                Messages.sendAuthenticationError(channel, format("User %s does not exist", clientUser));
+            if (isNull(clientUser) || clientUser.isEmpty()) {
+                Messages.sendAuthenticationError(channel, "user is empty");
             }
             if (wireProtocolSession.doAuthentication(password)) {
                 Messages.sendAuthenticationOK(channel)

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresWireProtocol.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresWireProtocol.java
@@ -51,7 +51,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.accio.base.metadata.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
-import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 
 public class PostgresWireProtocol
@@ -205,8 +204,8 @@ public class PostgresWireProtocol
     private void finishAuthentication(Channel channel, String password)
     {
         try {
-            String clientUser = wireProtocolSession.getClientUser();
-            if (isNull(clientUser) || clientUser.isEmpty()) {
+            Optional<String> clientUser = wireProtocolSession.getClientUser();
+            if (clientUser.isEmpty() || clientUser.get().isEmpty()) {
                 Messages.sendAuthenticationError(channel, "user is empty");
             }
             if (wireProtocolSession.doAuthentication(password)) {

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/WireProtocolSession.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/WireProtocolSession.java
@@ -157,10 +157,9 @@ public class WireProtocolSession
         return Optional.ofNullable(properties.getProperty("password"));
     }
 
-    @Nullable
-    public String getClientUser()
+    public Optional<String> getClientUser()
     {
-        return properties.getProperty("user");
+        return Optional.ofNullable(properties.getProperty("user"));
     }
 
     public String getDefaultDatabase()
@@ -195,11 +194,9 @@ public class WireProtocolSession
 
     public boolean doAuthentication(String password)
     {
-        String username = getClientUser();
-        if (username == null) {
-            return false;
-        }
-        return authentication.authenticate(username, password);
+        return getClientUser()
+                .filter(name -> authentication.authenticate(name, password))
+                .isPresent();
     }
 
     public Optional<List<Column>> describePortal(String name)

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/WireProtocolSession.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/WireProtocolSession.java
@@ -30,6 +30,7 @@ import io.accio.main.AccioMetastore;
 import io.accio.main.metadata.Metadata;
 import io.accio.main.pgcatalog.regtype.RegObjectFactory;
 import io.accio.main.sql.PostgreSqlRewrite;
+import io.accio.main.wireprotocol.auth.Authentication;
 import io.accio.main.wireprotocol.patterns.PostgreSqlRewriteUtil;
 import io.airlift.log.Logger;
 import io.trino.sql.parser.ParsingOptions;
@@ -88,6 +89,7 @@ public class WireProtocolSession
     private final AccioMetastore accioMetastore;
     private final CacheManager cacheManager;
     private final CachedTableMapping cachedTableMapping;
+    private final Authentication authentication;
 
     public WireProtocolSession(
             RegObjectFactory regObjectFactory,
@@ -96,7 +98,8 @@ public class WireProtocolSession
             AccioConfig accioConfig,
             AccioMetastore accioMetastore,
             CacheManager cacheManager,
-            CachedTableMapping cachedTableMapping)
+            CachedTableMapping cachedTableMapping,
+            Authentication authentication)
     {
         this.sqlParser = new SqlParser();
         this.regObjectFactory = requireNonNull(regObjectFactory, "regObjectFactory is null");
@@ -106,6 +109,7 @@ public class WireProtocolSession
         this.accioMetastore = requireNonNull(accioMetastore, "accioMetastore is null");
         this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
         this.cachedTableMapping = requireNonNull(cachedTableMapping, "cachedTableMapping is null");
+        this.authentication = requireNonNull(authentication, "authentication is null");
     }
 
     public int getParamTypeOid(String statementName, int fieldPosition)
@@ -191,7 +195,11 @@ public class WireProtocolSession
 
     public boolean doAuthentication(String password)
     {
-        return true;
+        String username = getClientUser();
+        if (username == null) {
+            return false;
+        }
+        return authentication.authenticate(username, password);
     }
 
     public Optional<List<Column>> describePortal(String name)

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/auth/Authentication.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/auth/Authentication.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.wireprotocol.auth;
+
+public interface Authentication
+{
+    boolean authenticate(String username, String password);
+}

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/auth/FileAuthentication.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/auth/FileAuthentication.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.wireprotocol.auth;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+public class FileAuthentication
+        implements Authentication
+{
+    private static final Logger LOG = Logger.get(FileAuthentication.class);
+    private final Map<String, String> accounts;
+
+    public FileAuthentication(File authFile)
+    {
+        this.accounts = authFile.exists() && authFile.isFile() ? parseAuthFile(authFile) : null;
+    }
+
+    @Override
+    public boolean authenticate(String username, String password)
+    {
+        if (accounts == null || accounts.isEmpty()) {
+            LOG.warn("No accounts found in auth file, disable the authentication");
+            return true;
+        }
+
+        return accounts.containsKey(username) &&
+                accounts.get(username).equals(password);
+    }
+
+    private Map<String, String> parseAuthFile(File authFile)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        try {
+            Files.readAllLines(authFile.toPath()).forEach(line -> {
+                try {
+                    String[] parts = line.split(" ");
+                    builder.put(parts[0], parts[1]);
+                }
+                catch (Exception e) {
+                    LOG.error("Failed to parse line %s", line);
+                }
+            });
+        }
+        catch (Exception e) {
+            LOG.error(e, "Failed to parse auth file %s", authFile);
+        }
+        return builder.build();
+    }
+}

--- a/accio-server/src/main/java/io/accio/server/module/PostgresWireProtocolModule.java
+++ b/accio-server/src/main/java/io/accio/server/module/PostgresWireProtocolModule.java
@@ -23,12 +23,12 @@ import io.accio.main.pgcatalog.PgCatalogManager;
 import io.accio.main.pgcatalog.regtype.RegObjectFactory;
 import io.accio.main.wireprotocol.PgWireProtocolExtraRewriter;
 import io.accio.main.wireprotocol.PostgresNetty;
+import io.accio.main.wireprotocol.auth.Authentication;
+import io.accio.main.wireprotocol.auth.FileAuthentication;
 import io.accio.main.wireprotocol.ssl.SslContextProvider;
 import io.accio.main.wireprotocol.ssl.TlsDataProvider;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.sql.parser.SqlParser;
-
-import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class PostgresWireProtocolModule
         extends AbstractConfigurationAwareModule
@@ -43,7 +43,8 @@ public class PostgresWireProtocolModule
     @Override
     protected void setup(Binder binder)
     {
-        configBinder(binder).bindConfig(PostgresWireProtocolConfig.class);
+        PostgresWireProtocolConfig config = buildConfigObject(PostgresWireProtocolConfig.class);
+        binder.bind(Authentication.class).toInstance(new FileAuthentication(config.getAuthFile()));
         binder.bind(SqlParser.class).in(Scopes.SINGLETON);
         binder.bind(TlsDataProvider.class).toInstance(tlsDataProvider);
         binder.bind(SslContextProvider.class).in(Scopes.SINGLETON);

--- a/accio-tests/pom.xml
+++ b/accio-tests/pom.xml
@@ -94,6 +94,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTest.java
+++ b/accio-tests/src/test/java/io/accio/testing/AbstractWireProtocolTest.java
@@ -56,9 +56,14 @@ public abstract class AbstractWireProtocolTest
     protected Connection createConnection()
             throws SQLException
     {
+        return createConnection(getDefaultProperties());
+    }
+
+    protected Connection createConnection(Properties props)
+            throws SQLException
+    {
         HostAndPort hostAndPort = server().getPgHostAndPort();
         String url = format("jdbc:postgresql://%s:%s/%s", hostAndPort.getHost(), hostAndPort.getPort(), getDefaultCatalog());
-        Properties props = getDefaultProperties();
         return DriverManager.getConnection(url, props);
     }
 

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import static io.accio.base.Utils.randomIntString;
 import static java.lang.String.format;
 import static java.lang.System.getenv;
+import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractWireProtocolTestWithBigQuery
         extends AbstractWireProtocolTest
@@ -45,6 +46,7 @@ public abstract class AbstractWireProtocolTestWithBigQuery
                 .put("bigquery.location", "asia-east1")
                 .put("bigquery.credentials-key", getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
                 .put("bigquery.metadata.schema.prefix", format("test_%s_", randomIntString()))
+                .put("pg-wire-protocol.auth.file", requireNonNull(getClass().getClassLoader().getResource("accounts")).getPath())
                 .put("accio.datasource.type", "bigquery");
 
         try {

--- a/accio-tests/src/test/resources/accounts
+++ b/accio-tests/src/test/resources/accounts
@@ -1,0 +1,7 @@
+pekochan pekopeko
+ina wah
+gura a
+accio ignored
+empty
+canner ignored
+ emptypass


### PR DESCRIPTION
# Description
Support to import an account file to do create some accounts in Accio.

## New config
`pg-wire-protocol.auth.file` is the path to the account file.
The file format is `userName password`. Ex.
```
pekochan pekopeko
ina wah
gura a
```
If accounts file isn't exist or is empty, the authentication is disable.