### PR TITLE
Add analysis sql web api

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
@@ -23,8 +23,8 @@ import io.accio.base.dto.Metric;
 import io.accio.base.dto.Model;
 import io.accio.base.dto.Relationship;
 import io.accio.base.dto.View;
+import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionRelation;
-import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.Table;
@@ -186,7 +186,7 @@ public class Analysis
                 CatalogSchemaTableName tableName,
                 String columnName,
                 Operator operator,
-                Literal value)
+                Expression value)
         {
             this.tableName = requireNonNull(tableName);
             this.columnName = requireNonNull(columnName);

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalysis.java
@@ -14,21 +14,41 @@
 
 package io.accio.base.sqlrewrite.analyzer;
 
-import java.util.List;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
 
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionAnalysis
 {
     private final List<Field> collectedFields;
+    private final Map<NodeRef<Expression>, Field> referencedFields;
+    private final List<ComparisonExpression> predicates;
 
-    public ExpressionAnalysis(List<Field> collectedFields)
+    public ExpressionAnalysis(Map<NodeRef<Expression>, Field> referenceFields, List<ComparisonExpression> predicates)
     {
-        this.collectedFields = requireNonNull(collectedFields);
+        this.referencedFields = requireNonNull(referenceFields);
+        this.collectedFields = referenceFields.values().stream().collect(toImmutableList());
+        this.predicates = requireNonNull(predicates);
     }
 
     public List<Field> getCollectedFields()
     {
         return collectedFields;
+    }
+
+    public Map<NodeRef<Expression>, Field> getReferencedFields()
+    {
+        return referencedFields;
+    }
+
+    public List<ComparisonExpression> getPredicates()
+    {
+        return predicates;
     }
 }

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -31,7 +31,6 @@ import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.Join;
 import io.trino.sql.tree.JoinCriteria;
 import io.trino.sql.tree.JoinOn;
-import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.QualifiedName;
@@ -277,7 +276,7 @@ public final class StatementAnalyzer
             ExpressionAnalysis expressionAnalysis = ExpressionAnalyzer.analyze(scope, node);
             Map<NodeRef<Expression>, Field> fields = expressionAnalysis.getReferencedFields();
             expressionAnalysis.getPredicates().stream()
-                    .filter(f -> PREDICATE_MATCHER.shapeMatches(f))
+                    .filter(PREDICATE_MATCHER::shapeMatches)
                     .forEach(comparisonExpression -> {
                         Expression expression = comparisonExpression.getLeft();
                         Optional.ofNullable(fields.get(NodeRef.of(expression)))
@@ -286,7 +285,7 @@ public final class StatementAnalyzer
                                                 field.getTableName(),
                                                 field.getColumnName(),
                                                 comparisonExpression.getOperator(),
-                                                (Literal) comparisonExpression.getRight())));
+                                                comparisonExpression.getRight())));
                     });
         }
 

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/matcher/Matcher.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/matcher/Matcher.java
@@ -1,0 +1,8 @@
+package io.accio.base.sqlrewrite.analyzer.matcher;
+
+import io.trino.sql.tree.Node;
+
+public interface Matcher
+{
+    boolean shapeMatches(Node node);
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/matcher/PredicateMatcher.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/matcher/PredicateMatcher.java
@@ -1,0 +1,29 @@
+package io.accio.base.sqlrewrite.analyzer.matcher;
+
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.DereferenceExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Literal;
+import io.trino.sql.tree.Node;
+
+public class PredicateMatcher
+        implements Matcher
+{
+    public static final PredicateMatcher PREDICATE_MATCHER = new PredicateMatcher();
+
+    private PredicateMatcher() {}
+
+    @Override
+    public boolean shapeMatches(Node node)
+    {
+        if (!(node instanceof ComparisonExpression)) {
+            return false;
+        }
+
+        Expression left = ((ComparisonExpression) node).getLeft();
+        Expression right = ((ComparisonExpression) node).getRight();
+
+        return (left instanceof DereferenceExpression || left instanceof Identifier) && right instanceof Literal;
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/matcher/PredicateMatcher.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/matcher/PredicateMatcher.java
@@ -24,6 +24,7 @@ public class PredicateMatcher
         Expression left = ((ComparisonExpression) node).getLeft();
         Expression right = ((ComparisonExpression) node).getRight();
 
-        return (left instanceof DereferenceExpression || left instanceof Identifier) && right instanceof Literal;
+        return (left instanceof DereferenceExpression || left instanceof Identifier) &&
+                (right instanceof Literal || right instanceof DereferenceExpression || right instanceof Identifier);
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
@@ -22,15 +22,24 @@ import io.accio.base.SessionContext;
 import io.accio.base.dto.Manifest;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.function.Function;
 
 import static io.accio.base.AccioMDL.EMPTY;
 import static io.accio.base.AccioMDL.fromManifest;
+import static io.accio.base.AccioTypes.DATE;
+import static io.accio.base.AccioTypes.INTEGER;
 import static io.accio.base.CatalogSchemaTableName.catalogSchemaTableName;
+import static io.accio.base.dto.Column.column;
 import static io.accio.base.dto.Column.varcharColumn;
 import static io.accio.base.dto.Model.model;
+import static io.accio.base.sqlrewrite.analyzer.Analysis.SimplePredicate;
 import static io.accio.base.sqlrewrite.analyzer.StatementAnalyzer.analyze;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,5 +105,32 @@ public class TestStatementAnalyzer
         expected.putAll(catalogSchemaTableName("test", "test", "table_1"), ImmutableList.of("c1", "c2"));
         expected.putAll(catalogSchemaTableName("test", "test", "table_2"), ImmutableList.of("c1", "c2"));
         assertThat(analyzeSql.apply("SELECT t1.c1, t2.c1, t2.c2 FROM table_1 t1 JOIN table_2 t2 ON t1.c2 = t2.c1").getCollectedColumns()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testGetSimplePredicates()
+    {
+        SessionContext sessionContext = SessionContext.builder().setCatalog("test").setSchema("test").build();
+        Manifest manifest = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("test")
+                .setModels(ImmutableList.of(
+                        model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), column("c2", INTEGER, null, true))),
+                        model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), column("c2", DATE, null, true)))))
+                .build();
+        Function<String, Analysis> analyzeSql = (sql) -> analyze(
+                sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL)),
+                sessionContext,
+                fromManifest(manifest));
+
+        CatalogSchemaTableName t1 = new CatalogSchemaTableName("test", "test", "table_1");
+        CatalogSchemaTableName t2 = new CatalogSchemaTableName("test", "test", "table_2");
+        assertThat(analyzeSql.apply("SELECT t1.c1, t2.c1, t2.c2 FROM table_1 t1 JOIN table_2 t2 ON t1.c2 = t2.c1\n" +
+                "WHERE t1.c1 = 'foo' AND t1.c2 >= 123 OR t2.c1 != 'bar' OR t2.c2 < DATE '2020-01-01'").getSimplePredicates())
+                .containsExactlyInAnyOrderElementsOf(List.of(
+                        new SimplePredicate(t1, "c1", ComparisonExpression.Operator.EQUAL, new StringLiteral("foo")),
+                        new SimplePredicate(t1, "c2", ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL, new LongLiteral("123")),
+                        new SimplePredicate(t2, "c1", ComparisonExpression.Operator.NOT_EQUAL, new StringLiteral("bar")),
+                        new SimplePredicate(t2, "c2", ComparisonExpression.Operator.LESS_THAN, new GenericLiteral("DATE", "2020-01-01"))));
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
@@ -23,8 +23,10 @@ import io.accio.base.dto.Manifest;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
@@ -126,9 +128,10 @@ public class TestStatementAnalyzer
         CatalogSchemaTableName t1 = new CatalogSchemaTableName("test", "test", "table_1");
         CatalogSchemaTableName t2 = new CatalogSchemaTableName("test", "test", "table_2");
         assertThat(analyzeSql.apply("SELECT t1.c1, t2.c1, t2.c2 FROM table_1 t1 JOIN table_2 t2 ON t1.c2 = t2.c1\n" +
-                "WHERE t1.c1 = 'foo' AND t1.c2 >= 123 OR t2.c1 != 'bar' OR t2.c2 < DATE '2020-01-01'").getSimplePredicates())
+                "WHERE t1.c1 = 'foo' AND t1.c2 >= 123 OR t2.c1 != 'bar' OR t2.c2 < DATE '2020-01-01' AND t1.c1 != t2.c1").getSimplePredicates())
                 .containsExactlyInAnyOrderElementsOf(List.of(
                         new SimplePredicate(t1, "c1", ComparisonExpression.Operator.EQUAL, new StringLiteral("foo")),
+                        new SimplePredicate(t1, "c1", ComparisonExpression.Operator.NOT_EQUAL, DereferenceExpression.from(QualifiedName.of("t2", "c1"))),
                         new SimplePredicate(t1, "c2", ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL, new LongLiteral("123")),
                         new SimplePredicate(t2, "c1", ComparisonExpression.Operator.NOT_EQUAL, new StringLiteral("bar")),
                         new SimplePredicate(t2, "c2", ComparisonExpression.Operator.LESS_THAN, new GenericLiteral("DATE", "2020-01-01"))));

--- a/accio-main/src/main/java/io/accio/main/web/AnalysisResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/AnalysisResource.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.web;
+
+import io.accio.base.AccioMDL;
+import io.accio.base.AnalyzedMDL;
+import io.accio.base.SessionContext;
+import io.accio.base.sqlrewrite.analyzer.Analysis;
+import io.accio.base.sqlrewrite.analyzer.StatementAnalyzer;
+import io.accio.main.AccioMetastore;
+import io.accio.main.web.dto.PredicateDto;
+import io.accio.main.web.dto.SqlAnalysisInputDto;
+import io.accio.main.web.dto.SqlAnalysisOutputDto;
+import io.trino.sql.tree.QualifiedName;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.accio.base.sqlrewrite.Utils.parseSql;
+import static io.accio.base.sqlrewrite.analyzer.Analysis.SimplePredicate;
+import static io.accio.main.web.AccioExceptionMapper.bindAsyncResponse;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/v1/analysis")
+public class AnalysisResource
+{
+    private final AccioMetastore accioMetastore;
+
+    @Inject
+    public AnalysisResource(
+            AccioMetastore accioMetastore)
+    {
+        this.accioMetastore = requireNonNull(accioMetastore, "accioMetastore is null");
+    }
+
+    @GET
+    @Path("/sql")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public void getSqlAnalysis(
+            SqlAnalysisInputDto inputDto,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        CompletableFuture
+                .supplyAsync(() -> {
+                    AccioMDL mdl;
+                    if (inputDto.getManifest() == null) {
+                        AnalyzedMDL analyzedMDL = accioMetastore.getAnalyzedMDL();
+                        mdl = analyzedMDL.getAccioMDL();
+                    }
+                    else {
+                        mdl = AccioMDL.fromManifest(inputDto.getManifest());
+                    }
+                    Analysis analysis = StatementAnalyzer.analyze(
+                            parseSql(inputDto.getSql()),
+                            SessionContext.builder().setCatalog(mdl.getCatalog()).setSchema(mdl.getSchema()).build(),
+                            mdl);
+                    return toSqlAnalysisOutputDto(analysis.getSimplePredicates());
+                })
+                .whenComplete(bindAsyncResponse(asyncResponse));
+    }
+
+    private static List<SqlAnalysisOutputDto> toSqlAnalysisOutputDto(List<SimplePredicate> predicates)
+    {
+        return predicates.stream()
+                .collect(groupingBy(predicate -> QualifiedName.of(
+                        predicate.getTableName().getSchemaTableName().getTableName(),
+                        predicate.getColumnName())))
+                .entrySet()
+                .stream()
+                .map(e ->
+                        new SqlAnalysisOutputDto(
+                                e.getKey().getParts().get(0),
+                                e.getKey().getParts().get(1),
+                                e.getValue().stream()
+                                        .map(simplePredicate -> new PredicateDto(simplePredicate.getOperator(), simplePredicate.getValue()))
+                                        .collect(toImmutableList())))
+                .collect(toImmutableList());
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/web/LineageResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/LineageResource.java
@@ -22,7 +22,6 @@ import io.accio.base.sqlrewrite.AccioDataLineage;
 import io.accio.main.AccioMetastore;
 import io.accio.main.web.dto.ColumnLineageInputDto;
 import io.accio.main.web.dto.LineageResult;
-import io.accio.main.web.dto.SqlLineageInputDto;
 import io.trino.sql.tree.QualifiedName;
 
 import javax.inject.Inject;
@@ -121,14 +120,5 @@ public class LineageResource
             }
         }
         throw new IllegalArgumentException("Dataset " + objectName + " is not a model, metric or cumulative metric");
-    }
-
-    @GET
-    @Path("sql")
-    public void getSqlLineage(
-            SqlLineageInputDto inputDto,
-            @Suspended AsyncResponse asyncResponse)
-    {
-        // TODO: wait sql lineage implemented
     }
 }

--- a/accio-main/src/main/java/io/accio/main/web/dto/PredicateDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/PredicateDto.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PredicateDto
+{
+    private final String operator;
+    private final String value;
+
+    @JsonCreator
+    public PredicateDto(
+            @JsonProperty("operator") String operator,
+            @JsonProperty("value") String value)
+    {
+        this.operator = requireNonNull(operator);
+        this.value = requireNonNull(value);
+    }
+
+    @JsonProperty
+    public String getOperator()
+    {
+        return operator;
+    }
+
+    @JsonProperty
+    public String getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PredicateDto that = (PredicateDto) o;
+        return Objects.equals(operator, that.operator) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(operator, value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("operator", operator)
+                .add("value", value)
+                .toString();
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/web/dto/SqlAnalysisInputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/SqlAnalysisInputDto.java
@@ -18,13 +18,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.accio.base.dto.Manifest;
 
-public class SqlLineageInputDto
+public class SqlAnalysisInputDto
 {
     private final Manifest manifest;
     private final String sql;
 
     @JsonCreator
-    public SqlLineageInputDto(
+    public SqlAnalysisInputDto(
             @JsonProperty("manifest") Manifest manifest,
             @JsonProperty("sql") String sql)
     {

--- a/accio-main/src/main/java/io/accio/main/web/dto/SqlAnalysisOutputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/SqlAnalysisOutputDto.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class SqlAnalysisOutputDto
+{
+    private final String modelName;
+    private final String columnName;
+    private final List<PredicateDto> predicates;
+
+    @JsonCreator
+    public SqlAnalysisOutputDto(
+            @JsonProperty("modelName") String modelName,
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("predicates") List<PredicateDto> predicates)
+    {
+        this.modelName = requireNonNull(modelName);
+        this.columnName = requireNonNull(columnName);
+        this.predicates = requireNonNull(predicates);
+    }
+
+    @JsonProperty
+    public String getModelName()
+    {
+        return modelName;
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public List<PredicateDto> getPredicates()
+    {
+        return predicates;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SqlAnalysisOutputDto that = (SqlAnalysisOutputDto) o;
+        return Objects.equals(modelName, that.modelName) && Objects.equals(columnName, that.columnName) && Objects.equals(predicates, that.predicates);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(modelName, columnName, predicates);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("modelName", modelName)
+                .add("columnName", columnName)
+                .add("predicates", predicates)
+                .toString();
+    }
+}

--- a/accio-server/src/main/java/io/accio/server/module/WebModule.java
+++ b/accio-server/src/main/java/io/accio/server/module/WebModule.java
@@ -19,6 +19,7 @@ import com.google.inject.Scopes;
 import io.accio.main.PreviewService;
 import io.accio.main.pgcatalog.PgCatalogManager;
 import io.accio.main.web.AccioExceptionMapper;
+import io.accio.main.web.AnalysisResource;
 import io.accio.main.web.CacheResource;
 import io.accio.main.web.LineageResource;
 import io.accio.main.web.MDLResource;
@@ -35,6 +36,7 @@ public class WebModule
         jaxrsBinder(binder).bind(MDLResource.class);
         jaxrsBinder(binder).bind(LineageResource.class);
         jaxrsBinder(binder).bind(CacheResource.class);
+        jaxrsBinder(binder).bind(AnalysisResource.class);
         jaxrsBinder(binder).bindInstance(new AccioExceptionMapper());
         binder.bind(PreviewService.class).in(Scopes.SINGLETON);
         binder.bind(PgCatalogManager.class).in(Scopes.SINGLETON);

--- a/accio-tests/src/test/java/io/accio/testing/RequireAccioServer.java
+++ b/accio-tests/src/test/java/io/accio/testing/RequireAccioServer.java
@@ -24,6 +24,8 @@ import io.accio.main.web.dto.ColumnLineageInputDto;
 import io.accio.main.web.dto.ErrorMessageDto;
 import io.accio.main.web.dto.LineageResult;
 import io.accio.main.web.dto.PreviewDto;
+import io.accio.main.web.dto.SqlAnalysisInputDto;
+import io.accio.main.web.dto.SqlAnalysisOutputDto;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
@@ -70,6 +72,8 @@ public abstract class RequireAccioServer
     private static final JsonCodec<PreviewDto> PREVIEW_DTO_CODEC = jsonCodec(PreviewDto.class);
     private static final JsonCodec<ColumnLineageInputDto> COLUMN_LINEAGE_INPUT_DTO_CODEC = jsonCodec(ColumnLineageInputDto.class);
     private static final JsonCodec<List<LineageResult>> MODEL_LINEAGE_RESULT_LIST_CODEC = listJsonCodec(LineageResult.class);
+    private static final JsonCodec<SqlAnalysisInputDto> SQL_ANALYSIS_INPUT_DTO_CODEC = jsonCodec(SqlAnalysisInputDto.class);
+    private static final JsonCodec<List<SqlAnalysisOutputDto>> SQL_ANALYSIS_OUTPUT_LIST_CODEC = listJsonCodec(SqlAnalysisOutputDto.class);
 
     public RequireAccioServer() {}
 
@@ -212,6 +216,21 @@ public abstract class RequireAccioServer
             getWebApplicationException(response);
         }
         return MODEL_LINEAGE_RESULT_LIST_CODEC.fromJson(response.getBody());
+    }
+
+    protected List<SqlAnalysisOutputDto> getSqlAnalysis(SqlAnalysisInputDto inputDto)
+    {
+        Request request = prepareGet()
+                .setUri(server().getHttpServerBasedUrl().resolve("/v1/analysis/sql"))
+                .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .setBodyGenerator(jsonBodyGenerator(SQL_ANALYSIS_INPUT_DTO_CODEC, inputDto))
+                .build();
+
+        StringResponseHandler.StringResponse response = executeHttpRequest(request, createStringResponseHandler());
+        if (response.getStatusCode() != 200) {
+            getWebApplicationException(response);
+        }
+        return SQL_ANALYSIS_OUTPUT_LIST_CODEC.fromJson(response.getBody());
     }
 
     public static void getWebApplicationException(StringResponseHandler.StringResponse response)

--- a/accio-tests/src/test/java/io/accio/testing/TestAnalysisResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestAnalysisResource.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.accio.base.dto.Manifest;
+import io.accio.base.dto.Model;
+import io.accio.main.web.dto.PredicateDto;
+import io.accio.main.web.dto.SqlAnalysisInputDto;
+import io.accio.main.web.dto.SqlAnalysisOutputDto;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.accio.base.AccioTypes.DATE;
+import static io.accio.base.AccioTypes.INTEGER;
+import static io.accio.base.AccioTypes.VARCHAR;
+import static io.accio.base.dto.Column.column;
+import static io.accio.base.dto.Column.varcharColumn;
+import static io.accio.base.dto.Manifest.MANIFEST_JSON_CODEC;
+import static io.accio.base.dto.Model.model;
+import static io.accio.testing.AbstractTestFramework.withDefaultCatalogSchema;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAnalysisResource
+        extends RequireAccioServer
+{
+    private Model customer;
+
+    @Override
+    protected TestingAccioServer createAccioServer()
+    {
+        initData();
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(customer))
+                .build();
+
+        Path mdlDir;
+        try {
+            mdlDir = Files.createTempDirectory("acciomdls");
+            Path accioMDLFilePath = mdlDir.resolve("acciomdl.json");
+            Files.write(accioMDLFilePath, MANIFEST_JSON_CODEC.toJsonBytes(manifest));
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("accio.directory", mdlDir.toAbsolutePath().toString())
+                .put("accio.datasource.type", "duckdb");
+
+        return TestingAccioServer.builder()
+                .setRequiredConfigs(properties.build())
+                .build();
+    }
+
+    private void initData()
+    {
+        customer = model("Customer",
+                "select * from main.customer",
+                List.of(
+                        column("custkey", INTEGER, null, true),
+                        column("name", VARCHAR, null, true),
+                        column("address", VARCHAR, null, true),
+                        column("nationkey", INTEGER, null, true),
+                        column("phone", VARCHAR, null, true),
+                        column("acctbal", INTEGER, null, true),
+                        column("mktsegment", VARCHAR, null, true),
+                        column("comment", VARCHAR, null, true)),
+                "custkey");
+    }
+
+    @Test
+    public void testAnalysisSqlDefaultManifest()
+    {
+        List<SqlAnalysisOutputDto> results = getSqlAnalysis(new SqlAnalysisInputDto(null, "SELECT * FROM Customer WHERE custkey >= 100 AND custkey <= 123 OR name != 'foo'"));
+        assertThat(results.size()).isEqualTo(2);
+
+        List<SqlAnalysisOutputDto> expected = ImmutableList.<SqlAnalysisOutputDto>builder()
+                .add(new SqlAnalysisOutputDto("Customer", "custkey",
+                        List.of(new PredicateDto(">=", "100"), new PredicateDto("<=", "123"))))
+                .add(new SqlAnalysisOutputDto("Customer", "name", List.of(new PredicateDto("<>", "'foo'"))))
+                .build();
+
+        assertThat(results).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    public void testAnalysisSqlCustomManifest()
+    {
+        Manifest manifest = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("test")
+                .setModels(ImmutableList.of(
+                        model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), column("c2", INTEGER, null, true))),
+                        model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), column("c2", DATE, null, true)))))
+                .build();
+
+        List<SqlAnalysisOutputDto> results = getSqlAnalysis(
+                new SqlAnalysisInputDto(manifest,
+                        "SELECT t1.c1, t2.c1, t2.c2 FROM table_1 t1 JOIN table_2 t2 ON t1.c2 = t2.c1\n" +
+                                "WHERE t1.c1 = 'foo' AND t1.c2 >= 123 OR t2.c1 != 'bar' OR t2.c2 < DATE '2020-01-01'"));
+        assertThat(results.size()).isEqualTo(4);
+
+        List<SqlAnalysisOutputDto> expected = ImmutableList.<SqlAnalysisOutputDto>builder()
+                .add(new SqlAnalysisOutputDto("table_1", "c1", List.of(new PredicateDto("=", "'foo'"))))
+                .add(new SqlAnalysisOutputDto("table_1", "c2", List.of(new PredicateDto(">=", "123"))))
+                .add(new SqlAnalysisOutputDto("table_2", "c1", List.of(new PredicateDto("<>", "'bar'"))))
+                .add(new SqlAnalysisOutputDto("table_2", "c2", List.of(new PredicateDto("<", "DATE '2020-01-01'"))))
+                .build();
+
+        assertThat(results).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    public void testSqlAnalysisEmpty()
+    {
+        assertThat(getSqlAnalysis(new SqlAnalysisInputDto(null, "SELECT * FROM Customer")).size()).isEqualTo(0);
+        assertThat(getSqlAnalysis(new SqlAnalysisInputDto(null, "SELECT custkey = 123 FROM Customer")).size()).isEqualTo(0);
+    }
+}

--- a/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
@@ -25,10 +25,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static io.accio.base.Utils.randomIntString;
 import static io.accio.base.dto.Column.column;
 import static io.accio.base.dto.Manifest.MANIFEST_JSON_CODEC;
 import static io.accio.base.dto.Model.model;
 import static io.accio.testing.WebApplicationExceptionAssert.assertWebApplicationException;
+import static java.lang.String.format;
 import static java.lang.System.getenv;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,6 +73,7 @@ public class TestMDLResource
                 .put("bigquery.project-id", getenv("TEST_BIG_QUERY_PROJECT_ID"))
                 .put("bigquery.location", "asia-east1")
                 .put("bigquery.credentials-key", getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
+                .put("bigquery.metadata.schema.prefix", format("test_%s_", randomIntString()))
                 .put("accio.directory", mdlDir.toAbsolutePath().toString())
                 .put("accio.datasource.type", "bigquery");
 


### PR DESCRIPTION
# Description
Add new web api /v1/analysis/api, this api will retrieve predicates in where-clause. Note that this api only catch predicate format in `[Identifer/dereferenceExpression] [operator] [literal/identifier/dereferenceExpression]`. e.g. `column = 'foo'` will be caught while `column_a = column_b` won't be caught since column_b is an identifier not literal.

## input dto
manifest is optional, if manifest is not provided in input dto, mdl provided in accio server will be used.
```json
{
  "manifest":  {...},
  "sql": "SELECT * FROM Orders WHERE orderdate >= DATE '2022/07/12' AND orderkey <= 123 OR orderkey >= 100"
}
```

## output dto
```json
[
  {
     "modelName": "Orders",
     "columnName": "orderdate",
     "predicates": [
       {
         "operator": ">=",
         "value": "DATE '2022/07/12'"
       }
     ]
  },
  {
     "modelName": "Orders",
     "columnName": "orderkey"
     "predicates": [
       {
         "operator": "<=",
         "value": "123"
       },
       {
         "operator": ">=",
         "value": "100"
       }
     ]
  }
]
```
