### PR TITLE
Shutdown all executors to avoid thread leak

### DIFF
--- a/accio-cache/src/main/java/io/accio/cache/CacheManager.java
+++ b/accio-cache/src/main/java/io/accio/cache/CacheManager.java
@@ -298,7 +298,9 @@ public class CacheManager
     @PreDestroy
     public void stop()
     {
-        refreshExecutor.shutdown();
+        refreshExecutor.shutdownNow();
+        retryExecutor.shutdownNow();
+        executorService.shutdownNow();
         cleanTempFiles();
     }
 

--- a/accio-cache/src/main/java/io/accio/cache/DuckdbTaskManager.java
+++ b/accio-cache/src/main/java/io/accio/cache/DuckdbTaskManager.java
@@ -5,6 +5,7 @@ import io.accio.base.client.AutoCloseableIterator;
 import io.accio.base.client.duckdb.DuckDBConfig;
 import io.accio.base.client.duckdb.DuckdbClient;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import java.io.Closeable;
@@ -93,6 +94,7 @@ public class DuckdbTaskManager
         }
     }
 
+    @PreDestroy
     @Override
     public void close()
             throws IOException


### PR DESCRIPTION
This won't happen in production since the only way to close accio server means kill process. 
While some executor is not shutdown and cause thread leak in e2e tests.