### PR TITLE
Implement basic Type Coercion for BigQuery connector

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
@@ -76,7 +76,8 @@ public class AccioSqlRewrite
     @Override
     public Statement apply(Statement root, SessionContext sessionContext, AnalyzedMDL analyzedMDL)
     {
-        Analysis analysis = StatementAnalyzer.analyze(root, sessionContext, analyzedMDL.getAccioMDL());
+        Analysis analysis = new Analysis(root);
+        StatementAnalyzer.analyze(analysis, root, sessionContext, analyzedMDL.getAccioMDL());
         return apply(root, sessionContext, analysis, analyzedMDL);
     }
 

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/BaseRewriter.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/BaseRewriter.java
@@ -14,92 +14,39 @@
 
 package io.accio.base.sqlrewrite;
 
-import io.trino.sql.tree.AddColumn;
-import io.trino.sql.tree.AliasedRelation;
-import io.trino.sql.tree.AllColumns;
-import io.trino.sql.tree.Analyze;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.ArrayConstructor;
-import io.trino.sql.tree.AstVisitor;
-import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BindExpression;
 import io.trino.sql.tree.BooleanLiteral;
-import io.trino.sql.tree.Call;
-import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CharLiteral;
 import io.trino.sql.tree.CoalesceExpression;
-import io.trino.sql.tree.ColumnDefinition;
-import io.trino.sql.tree.Comment;
-import io.trino.sql.tree.Commit;
 import io.trino.sql.tree.ComparisonExpression;
-import io.trino.sql.tree.CreateRole;
-import io.trino.sql.tree.CreateSchema;
-import io.trino.sql.tree.CreateTable;
-import io.trino.sql.tree.CreateTableAsSelect;
-import io.trino.sql.tree.CreateView;
-import io.trino.sql.tree.Cube;
-import io.trino.sql.tree.CurrentPath;
-import io.trino.sql.tree.CurrentTime;
-import io.trino.sql.tree.CurrentUser;
 import io.trino.sql.tree.DataType;
 import io.trino.sql.tree.DataTypeParameter;
 import io.trino.sql.tree.DateTimeDataType;
-import io.trino.sql.tree.Deallocate;
 import io.trino.sql.tree.DecimalLiteral;
-import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.DereferenceExpression;
-import io.trino.sql.tree.DescribeInput;
-import io.trino.sql.tree.DescribeOutput;
 import io.trino.sql.tree.DoubleLiteral;
-import io.trino.sql.tree.DropColumn;
-import io.trino.sql.tree.DropRole;
-import io.trino.sql.tree.DropSchema;
-import io.trino.sql.tree.DropTable;
-import io.trino.sql.tree.DropView;
-import io.trino.sql.tree.Except;
-import io.trino.sql.tree.Execute;
 import io.trino.sql.tree.ExistsPredicate;
-import io.trino.sql.tree.Explain;
-import io.trino.sql.tree.ExplainOption;
-import io.trino.sql.tree.Extract;
-import io.trino.sql.tree.FetchFirst;
 import io.trino.sql.tree.FieldReference;
-import io.trino.sql.tree.Format;
-import io.trino.sql.tree.FrameBound;
 import io.trino.sql.tree.FunctionCall;
-import io.trino.sql.tree.FunctionRelation;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.GenericLiteral;
-import io.trino.sql.tree.Grant;
-import io.trino.sql.tree.GrantRoles;
-import io.trino.sql.tree.GroupBy;
-import io.trino.sql.tree.GroupingElement;
-import io.trino.sql.tree.GroupingOperation;
-import io.trino.sql.tree.GroupingSets;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.IfExpression;
 import io.trino.sql.tree.InListExpression;
 import io.trino.sql.tree.InPredicate;
-import io.trino.sql.tree.Insert;
-import io.trino.sql.tree.Intersect;
 import io.trino.sql.tree.IntervalDayTimeDataType;
 import io.trino.sql.tree.IntervalLiteral;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
-import io.trino.sql.tree.Isolation;
-import io.trino.sql.tree.Join;
-import io.trino.sql.tree.JoinCriteria;
-import io.trino.sql.tree.JoinOn;
 import io.trino.sql.tree.LambdaArgumentDeclaration;
 import io.trino.sql.tree.LambdaExpression;
-import io.trino.sql.tree.Lateral;
-import io.trino.sql.tree.LikeClause;
 import io.trino.sql.tree.LikePredicate;
-import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
@@ -108,77 +55,23 @@ import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.NumericParameter;
-import io.trino.sql.tree.Offset;
-import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.Parameter;
-import io.trino.sql.tree.PathElement;
-import io.trino.sql.tree.PathSpecification;
-import io.trino.sql.tree.Prepare;
-import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QuantifiedComparisonExpression;
-import io.trino.sql.tree.Query;
-import io.trino.sql.tree.QueryBody;
-import io.trino.sql.tree.QuerySpecification;
-import io.trino.sql.tree.Relation;
-import io.trino.sql.tree.RenameColumn;
-import io.trino.sql.tree.RenameSchema;
-import io.trino.sql.tree.RenameTable;
-import io.trino.sql.tree.ResetSession;
-import io.trino.sql.tree.Revoke;
-import io.trino.sql.tree.RevokeRoles;
-import io.trino.sql.tree.Rollback;
-import io.trino.sql.tree.Rollup;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.RowDataType;
-import io.trino.sql.tree.SampledRelation;
 import io.trino.sql.tree.SearchedCaseExpression;
-import io.trino.sql.tree.Select;
-import io.trino.sql.tree.SelectItem;
-import io.trino.sql.tree.SetOperation;
-import io.trino.sql.tree.SetPath;
-import io.trino.sql.tree.SetRole;
-import io.trino.sql.tree.SetSession;
-import io.trino.sql.tree.ShowCatalogs;
-import io.trino.sql.tree.ShowColumns;
-import io.trino.sql.tree.ShowCreate;
-import io.trino.sql.tree.ShowFunctions;
-import io.trino.sql.tree.ShowGrants;
-import io.trino.sql.tree.ShowRoleGrants;
-import io.trino.sql.tree.ShowRoles;
-import io.trino.sql.tree.ShowSchemas;
-import io.trino.sql.tree.ShowSession;
-import io.trino.sql.tree.ShowStats;
-import io.trino.sql.tree.ShowTables;
 import io.trino.sql.tree.SimpleCaseExpression;
-import io.trino.sql.tree.SimpleGroupBy;
-import io.trino.sql.tree.SingleColumn;
-import io.trino.sql.tree.SortItem;
-import io.trino.sql.tree.StartTransaction;
-import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
-import io.trino.sql.tree.SymbolReference;
-import io.trino.sql.tree.Table;
-import io.trino.sql.tree.TableElement;
-import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.TimeLiteral;
 import io.trino.sql.tree.TimestampLiteral;
-import io.trino.sql.tree.TransactionAccessMode;
-import io.trino.sql.tree.TransactionMode;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.TypeParameter;
-import io.trino.sql.tree.Union;
-import io.trino.sql.tree.Unnest;
-import io.trino.sql.tree.Use;
-import io.trino.sql.tree.Values;
 import io.trino.sql.tree.WhenClause;
 import io.trino.sql.tree.Window;
-import io.trino.sql.tree.WindowFrame;
 import io.trino.sql.tree.WindowReference;
 import io.trino.sql.tree.WindowSpecification;
-import io.trino.sql.tree.With;
-import io.trino.sql.tree.WithQuery;
 
 import java.util.List;
 import java.util.Optional;
@@ -186,76 +79,8 @@ import java.util.Optional;
 import static java.util.stream.Collectors.toList;
 
 public class BaseRewriter<T>
-        extends AstVisitor<Node, T>
+        extends BaseTreeRewriter<T>
 {
-    @Override
-    protected Node visitNode(Node node, T context)
-    {
-        return node;
-    }
-
-    @Override
-    protected Node visitCreateTableAsSelect(CreateTableAsSelect node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new CreateTableAsSelect(
-                    node.getLocation().get(),
-                    node.getName(),
-                    visitAndCast(node.getQuery(), context),
-                    node.isNotExists(),
-                    node.getProperties(),
-                    node.isWithData(),
-                    node.getColumnAliases(),
-                    node.getComment());
-        }
-        return new CreateTableAsSelect(
-                node.getName(),
-                visitAndCast(node.getQuery(), context),
-                node.isNotExists(),
-                node.getProperties(),
-                node.isWithData(),
-                node.getColumnAliases(),
-                node.getComment());
-    }
-
-    @Override
-    protected Node visitQuery(Query node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Query(
-                    node.getLocation().get(),
-                    node.getWith().map(expression -> visitAndCast(expression, context)),
-                    visitAndCast(node.getQueryBody(), context),
-                    node.getOrderBy().map(expression -> visitAndCast(expression, context)),
-                    node.getOffset(),
-                    node.getLimit());
-        }
-        return new Query(
-                node.getWith().map(expression -> visitAndCast(expression, context)),
-                visitAndCast(node.getQueryBody(), context),
-                node.getOrderBy().map(expression -> visitAndCast(expression, context)),
-                node.getOffset(),
-                node.getLimit());
-    }
-
-    @Override
-    protected Node visitCurrentTime(CurrentTime node, T context)
-    {
-        return super.visitCurrentTime(node, context);
-    }
-
-    @Override
-    protected Node visitExtract(Extract node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            new Extract(
-                    node.getLocation().get(),
-                    visitAndCast(node.getExpression(), context),
-                    node.getField());
-        }
-        return new Extract(visitAndCast(node.getExpression(), context), node.getField());
-    }
-
     @Override
     protected Node visitCoalesceExpression(CoalesceExpression node, T context)
     {
@@ -286,167 +111,6 @@ public class BaseRewriter<T>
     }
 
     @Override
-    protected Node visitStatement(Statement node, T context)
-    {
-        return super.visitStatement(node, context);
-    }
-
-    @Override
-    protected Node visitPrepare(Prepare node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Prepare(
-                    node.getLocation().get(),
-                    node.getName(),
-                    visitAndCast(node.getStatement(), context));
-        }
-        return new Prepare(
-                node.getName(),
-                visitAndCast(node.getStatement(), context));
-    }
-
-    @Override
-    protected Node visitDeallocate(Deallocate node, T context)
-    {
-        return super.visitDeallocate(node, context);
-    }
-
-    @Override
-    protected Node visitExecute(Execute node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Execute(
-                    node.getLocation().get(),
-                    node.getName(),
-                    visitNodes(node.getParameters(), context));
-        }
-        return new Execute(node.getName(), visitNodes(node.getParameters(), context));
-    }
-
-    @Override
-    protected Node visitDescribeOutput(DescribeOutput node, T context)
-    {
-        return super.visitDescribeOutput(node, context);
-    }
-
-    @Override
-    protected Node visitDescribeInput(DescribeInput node, T context)
-    {
-        return super.visitDescribeInput(node, context);
-    }
-
-    @Override
-    protected Node visitExplain(Explain node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Explain(
-                    node.getLocation().get(),
-                    visitAndCast(node.getStatement(), context),
-                    node.getOptions());
-        }
-        return new Explain(
-                visitAndCast(node.getStatement(), context),
-                node.getOptions());
-    }
-
-    @Override
-    protected Node visitShowTables(ShowTables node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new ShowTables(
-                    node.getLocation().get(),
-                    node.getSchema(),
-                    node.getLikePattern(),
-                    node.getEscape());
-        }
-        return new ShowTables(
-                node.getSchema(),
-                node.getLikePattern(),
-                node.getEscape());
-    }
-
-    @Override
-    protected Node visitShowSchemas(ShowSchemas node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new ShowSchemas(
-                    node.getLocation().get(),
-                    node.getCatalog(),
-                    node.getLikePattern(),
-                    node.getEscape());
-        }
-        return new ShowSchemas(
-                node.getCatalog(),
-                node.getLikePattern(),
-                node.getEscape());
-    }
-
-    @Override
-    protected Node visitShowCatalogs(ShowCatalogs node, T context)
-    {
-        return super.visitShowCatalogs(node, context);
-    }
-
-    @Override
-    protected Node visitShowStats(ShowStats node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new ShowStats(
-                    node.getLocation(),
-                    visitAndCast(node.getRelation(), context));
-        }
-        return new ShowStats(visitAndCast(node.getRelation(), context));
-    }
-
-    @Override
-    protected Node visitShowCreate(ShowCreate node, T context)
-    {
-        if (node.getType() == ShowCreate.Type.TABLE) {
-            Table table = (Table) visitTable(new Table(node.getName()), context);
-            if (node.getLocation().isPresent()) {
-                return new ShowCreate(
-                        node.getLocation().get(),
-                        node.getType(),
-                        table.getName());
-            }
-            return new ShowCreate(
-                    node.getType(),
-                    table.getName());
-        }
-        return super.visitShowCreate(node, context);
-    }
-
-    @Override
-    protected Node visitShowFunctions(ShowFunctions node, T context)
-    {
-        return super.visitShowFunctions(node, context);
-    }
-
-    @Override
-    protected Node visitUse(Use node, T context)
-    {
-        return super.visitUse(node, context);
-    }
-
-    @Override
-    protected Node visitShowSession(ShowSession node, T context)
-    {
-        return super.visitShowSession(node, context);
-    }
-
-    @Override
-    protected Node visitSetSession(SetSession node, T context)
-    {
-        return super.visitSetSession(node, context);
-    }
-
-    @Override
-    protected Node visitResetSession(ResetSession node, T context)
-    {
-        return super.visitResetSession(node, context);
-    }
-
-    @Override
     protected Node visitGenericLiteral(GenericLiteral node, T context)
     {
         return super.visitGenericLiteral(node, context);
@@ -456,76 +120,6 @@ public class BaseRewriter<T>
     protected Node visitTimeLiteral(TimeLiteral node, T context)
     {
         return super.visitTimeLiteral(node, context);
-    }
-
-    @Override
-    protected Node visitExplainOption(ExplainOption node, T context)
-    {
-        return super.visitExplainOption(node, context);
-    }
-
-    @Override
-    protected Node visitRelation(Relation node, T context)
-    {
-        return super.visitRelation(node, context);
-    }
-
-    @Override
-    protected Node visitQueryBody(QueryBody node, T context)
-    {
-        return super.visitQueryBody(node, context);
-    }
-
-    @Override
-    protected Node visitOffset(Offset node, T context)
-    {
-        return super.visitOffset(node, context);
-    }
-
-    @Override
-    protected Node visitFetchFirst(FetchFirst node, T context)
-    {
-        return super.visitFetchFirst(node, context);
-    }
-
-    @Override
-    protected Node visitLimit(Limit node, T context)
-    {
-        return super.visitLimit(node, context);
-    }
-
-    @Override
-    protected Node visitSetOperation(SetOperation node, T context)
-    {
-        return super.visitSetOperation(node, context);
-    }
-
-    @Override
-    protected Node visitIntersect(Intersect node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Intersect(
-                    node.getLocation().get(),
-                    visitNodes(node.getRelations(), context),
-                    node.isDistinct());
-        }
-        return new Intersect(visitNodes(node.getRelations(), context), node.isDistinct());
-    }
-
-    @Override
-    protected Node visitExcept(Except node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Except(
-                    node.getLocation().get(),
-                    visitAndCast(node.getLeft(), context),
-                    visitAndCast(node.getRight(), context),
-                    node.isDistinct());
-        }
-        return new Except(
-                visitAndCast(node.getLeft(), context),
-                visitAndCast(node.getRight(), context),
-                node.isDistinct());
     }
 
     @Override
@@ -674,18 +268,6 @@ public class BaseRewriter<T>
     }
 
     @Override
-    protected Node visitSelectItem(SelectItem node, T context)
-    {
-        return super.visitSelectItem(node, context);
-    }
-
-    @Override
-    protected Node visitAllColumns(AllColumns node, T context)
-    {
-        return super.visitAllColumns(node, context);
-    }
-
-    @Override
     protected Node visitSearchedCaseExpression(SearchedCaseExpression node, T context)
     {
         if (node.getLocation().isPresent()) {
@@ -787,49 +369,6 @@ public class BaseRewriter<T>
     }
 
     @Override
-    protected Node visitUnnest(Unnest node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Unnest(
-                    node.getLocation().get(),
-                    visitNodes(node.getExpressions(), context),
-                    node.isWithOrdinality());
-        }
-        return new Unnest(visitNodes(node.getExpressions(), context), node.isWithOrdinality());
-    }
-
-    @Override
-    protected Node visitFunctionRelation(FunctionRelation node, T context)
-    {
-        return new FunctionRelation(
-                node.getLocation().orElse(null),
-                node.getName(),
-                node.getArguments());
-    }
-
-    @Override
-    protected Node visitLateral(Lateral node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Lateral(
-                    node.getLocation().get(),
-                    visitAndCast(node.getQuery(), context));
-        }
-        return new Lateral(visitAndCast(node.getQuery(), context));
-    }
-
-    @Override
-    protected Node visitValues(Values node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Values(
-                    node.getLocation().get(),
-                    visitNodes(node.getRows(), context));
-        }
-        return new Values(visitNodes(node.getRows(), context));
-    }
-
-    @Override
     protected Node visitRow(Row node, T context)
     {
         if (node.getLocation().isPresent()) {
@@ -838,22 +377,6 @@ public class BaseRewriter<T>
                     visitNodes(node.getItems(), context));
         }
         return new Row(visitNodes(node.getItems(), context));
-    }
-
-    @Override
-    protected Node visitSampledRelation(SampledRelation node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new SampledRelation(
-                    node.getLocation().get(),
-                    visitAndCast(node.getRelation(), context),
-                    node.getType(),
-                    visitAndCast(node.getSamplePercentage(), context));
-        }
-        return new SampledRelation(
-                visitAndCast(node.getRelation(), context),
-                node.getType(),
-                visitAndCast(node.getSamplePercentage(), context));
     }
 
     @Override
@@ -892,355 +415,6 @@ public class BaseRewriter<T>
     }
 
     @Override
-    protected Node visitWindowSpecification(WindowSpecification node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new WindowSpecification(
-                    node.getLocation().get(),
-                    node.getExistingWindowName(),
-                    visitNodes(node.getPartitionBy(), context),
-                    node.getOrderBy(),
-                    node.getFrame().map(expression -> visitAndCast(expression, context)));
-        }
-        return new WindowSpecification(
-                node.getExistingWindowName(),
-                visitNodes(node.getPartitionBy(), context),
-                node.getOrderBy(),
-                node.getFrame().map(expression -> visitAndCast(expression, context)));
-    }
-
-    @Override
-    protected Node visitWindowFrame(WindowFrame node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new WindowFrame(
-                    node.getLocation().get(),
-                    node.getType(),
-                    visitAndCast(node.getStart(), context),
-                    node.getEnd().map(expression -> visitAndCast(expression, context)),
-                    node.getMeasures(),
-                    node.getAfterMatchSkipTo(),
-                    node.getPatternSearchMode(),
-                    node.getPattern(),
-                    node.getSubsets(),
-                    node.getVariableDefinitions());
-        }
-        return new WindowFrame(
-                node.getType(),
-                visitAndCast(node.getStart(), context),
-                node.getEnd().map(expression -> visitAndCast(expression, context)),
-                node.getMeasures(),
-                node.getAfterMatchSkipTo(),
-                node.getPatternSearchMode(),
-                node.getPattern(),
-                node.getSubsets(),
-                node.getVariableDefinitions());
-    }
-
-    @Override
-    protected Node visitFrameBound(FrameBound node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new FrameBound(
-                    node.getLocation().get(),
-                    node.getType(),
-                    node.getValue().map(expression -> visitAndCast(expression, context)).orElse(null));
-        }
-        return new FrameBound(
-                node.getType(),
-                node.getValue().map(expression -> visitAndCast(expression, context)).orElse(null));
-    }
-
-    @Override
-    protected Node visitCallArgument(CallArgument node, T context)
-    {
-        return new CallArgument(
-                node.getLocation(),
-                node.getName(),
-                visitAndCast(node.getValue(), context));
-    }
-
-    @Override
-    protected Node visitTableElement(TableElement node, T context)
-    {
-        return super.visitTableElement(node, context);
-    }
-
-    @Override
-    protected Node visitColumnDefinition(ColumnDefinition node, T context)
-    {
-        return super.visitColumnDefinition(node, context);
-    }
-
-    @Override
-    protected Node visitLikeClause(LikeClause node, T context)
-    {
-        return super.visitLikeClause(node, context);
-    }
-
-    @Override
-    protected Node visitCreateSchema(CreateSchema node, T context)
-    {
-        return super.visitCreateSchema(node, context);
-    }
-
-    @Override
-    protected Node visitDropSchema(DropSchema node, T context)
-    {
-        return super.visitDropSchema(node, context);
-    }
-
-    @Override
-    protected Node visitRenameSchema(RenameSchema node, T context)
-    {
-        return super.visitRenameSchema(node, context);
-    }
-
-    @Override
-    protected Node visitCreateTable(CreateTable node, T context)
-    {
-        return super.visitCreateTable(node, context);
-    }
-
-    @Override
-    protected Node visitProperty(Property node, T context)
-    {
-        return super.visitProperty(node, context);
-    }
-
-    @Override
-    protected Node visitDropTable(DropTable node, T context)
-    {
-        return super.visitDropTable(node, context);
-    }
-
-    @Override
-    protected Node visitRenameTable(RenameTable node, T context)
-    {
-        return super.visitRenameTable(node, context);
-    }
-
-    @Override
-    protected Node visitComment(Comment node, T context)
-    {
-        return super.visitComment(node, context);
-    }
-
-    @Override
-    protected Node visitRenameColumn(RenameColumn node, T context)
-    {
-        return super.visitRenameColumn(node, context);
-    }
-
-    @Override
-    protected Node visitDropColumn(DropColumn node, T context)
-    {
-        return super.visitDropColumn(node, context);
-    }
-
-    @Override
-    protected Node visitAddColumn(AddColumn node, T context)
-    {
-        return super.visitAddColumn(node, context);
-    }
-
-    @Override
-    protected Node visitAnalyze(Analyze node, T context)
-    {
-        return super.visitAnalyze(node, context);
-    }
-
-    @Override
-    protected Node visitCreateView(CreateView node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new CreateView(
-                    node.getLocation().get(),
-                    node.getName(),
-                    visitAndCast(node.getQuery(), context),
-                    node.isReplace(),
-                    node.getComment(),
-                    node.getSecurity());
-        }
-        return new CreateView(
-                node.getName(),
-                visitAndCast(node.getQuery(), context),
-                node.isReplace(),
-                node.getComment(),
-                node.getSecurity());
-    }
-
-    @Override
-    protected Node visitDropView(DropView node, T context)
-    {
-        return super.visitDropView(node, context);
-    }
-
-    @Override
-    protected Node visitInsert(Insert node, T context)
-    {
-        return super.visitInsert(node, context);
-    }
-
-    @Override
-    protected Node visitCall(Call node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Call(
-                    node.getLocation().get(),
-                    node.getName(),
-                    visitNodes(node.getArguments(), context));
-        }
-        return new Call(node.getName(), visitNodes(node.getArguments(), context));
-    }
-
-    @Override
-    protected Node visitDelete(Delete node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Delete(
-                    node.getLocation().get(),
-                    visitAndCast(node.getTable(), context),
-                    node.getWhere().map(expression -> visitAndCast(expression, context)));
-        }
-        return new Delete(
-                visitAndCast(node.getTable(), context),
-                node.getWhere().map(expression -> visitAndCast(expression, context)));
-    }
-
-    @Override
-    protected Node visitStartTransaction(StartTransaction node, T context)
-    {
-        return super.visitStartTransaction(node, context);
-    }
-
-    @Override
-    protected Node visitCreateRole(CreateRole node, T context)
-    {
-        return super.visitCreateRole(node, context);
-    }
-
-    @Override
-    protected Node visitDropRole(DropRole node, T context)
-    {
-        return super.visitDropRole(node, context);
-    }
-
-    @Override
-    protected Node visitGrantRoles(GrantRoles node, T context)
-    {
-        return super.visitGrantRoles(node, context);
-    }
-
-    @Override
-    protected Node visitRevokeRoles(RevokeRoles node, T context)
-    {
-        return super.visitRevokeRoles(node, context);
-    }
-
-    @Override
-    protected Node visitSetRole(SetRole node, T context)
-    {
-        return super.visitSetRole(node, context);
-    }
-
-    @Override
-    protected Node visitGrant(Grant node, T context)
-    {
-        return super.visitGrant(node, context);
-    }
-
-    @Override
-    protected Node visitRevoke(Revoke node, T context)
-    {
-        return super.visitRevoke(node, context);
-    }
-
-    @Override
-    protected Node visitShowGrants(ShowGrants node, T context)
-    {
-        return super.visitShowGrants(node, context);
-    }
-
-    @Override
-    protected Node visitShowRoles(ShowRoles node, T context)
-    {
-        return super.visitShowRoles(node, context);
-    }
-
-    @Override
-    protected Node visitShowRoleGrants(ShowRoleGrants node, T context)
-    {
-        return super.visitShowRoleGrants(node, context);
-    }
-
-    @Override
-    protected Node visitSetPath(SetPath node, T context)
-    {
-        return super.visitSetPath(node, context);
-    }
-
-    @Override
-    protected Node visitPathSpecification(PathSpecification node, T context)
-    {
-        return super.visitPathSpecification(node, context);
-    }
-
-    @Override
-    protected Node visitPathElement(PathElement node, T context)
-    {
-        return super.visitPathElement(node, context);
-    }
-
-    @Override
-    protected Node visitTransactionMode(TransactionMode node, T context)
-    {
-        return super.visitTransactionMode(node, context);
-    }
-
-    @Override
-    protected Node visitIsolationLevel(Isolation node, T context)
-    {
-        return super.visitIsolationLevel(node, context);
-    }
-
-    @Override
-    protected Node visitTransactionAccessMode(TransactionAccessMode node, T context)
-    {
-        return super.visitTransactionAccessMode(node, context);
-    }
-
-    @Override
-    protected Node visitCommit(Commit node, T context)
-    {
-        return super.visitCommit(node, context);
-    }
-
-    @Override
-    protected Node visitRollback(Rollback node, T context)
-    {
-        return super.visitRollback(node, context);
-    }
-
-    @Override
-    protected Node visitAtTimeZone(AtTimeZone node, T context)
-    {
-        return super.visitAtTimeZone(node, context);
-    }
-
-    @Override
-    protected Node visitGroupingElement(GroupingElement node, T context)
-    {
-        return super.visitGroupingElement(node, context);
-    }
-
-    @Override
-    protected Node visitSymbolReference(SymbolReference node, T context)
-    {
-        return super.visitSymbolReference(node, context);
-    }
-
-    @Override
     protected Node visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, T context)
     {
         if (node.getLocation().isPresent()) {
@@ -1274,35 +448,6 @@ public class BaseRewriter<T>
                     visitAndCast(node.getFunction(), context));
         }
         return new BindExpression(visitNodes(node.getValues(), context), visitAndCast(node.getFunction(), context));
-    }
-
-    @Override
-    protected Node visitGroupingOperation(GroupingOperation node, T context)
-    {
-        return super.visitGroupingOperation(node, context);
-    }
-
-    @Override
-    protected Node visitCurrentUser(CurrentUser node, T context)
-    {
-        return super.visitCurrentUser(node, context);
-    }
-
-    @Override
-    protected Node visitCurrentPath(CurrentPath node, T context)
-    {
-        return super.visitCurrentPath(node, context);
-    }
-
-    @Override
-    protected Node visitFormat(Format node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Format(
-                    node.getLocation().get(),
-                    visitNodes(node.getArguments(), context));
-        }
-        return new Format(visitNodes(node.getArguments(), context));
     }
 
     @Override
@@ -1459,95 +604,6 @@ public class BaseRewriter<T>
     }
 
     @Override
-    protected Node visitQuerySpecification(QuerySpecification node, T context)
-    {
-        // Relations should be visited first for alias.
-        Optional<Relation> from = node.getFrom().map(expression -> visitAndCast(expression, context));
-
-        if (node.getLocation().isPresent()) {
-            return new QuerySpecification(
-                    node.getLocation().get(),
-                    visitAndCast(node.getSelect(), context),
-                    from,
-                    node.getWhere().map(expression -> visitAndCast(expression, context)),
-                    node.getGroupBy().map(expression -> visitAndCast(expression, context)),
-                    node.getHaving().map(expression -> visitAndCast(expression, context)),
-                    visitNodes(node.getWindows(), context),
-                    node.getOrderBy().map(expression -> visitAndCast(expression, context)),
-                    node.getOffset(),
-                    node.getLimit());
-        }
-        return new QuerySpecification(
-                visitAndCast(node.getSelect(), context),
-                from,
-                node.getWhere().map(expression -> visitAndCast(expression, context)),
-                node.getGroupBy().map(expression -> visitAndCast(expression, context)),
-                node.getHaving().map(expression -> visitAndCast(expression, context)),
-                visitNodes(node.getWindows(), context),
-                node.getOrderBy().map(expression -> visitAndCast(expression, context)),
-                node.getOffset(),
-                node.getLimit());
-    }
-
-    @Override
-    protected Node visitShowColumns(ShowColumns node, T context)
-    {
-        Table table = (Table) visitTable(new Table(node.getTable()), context);
-        if (node.getLocation().isPresent()) {
-            return new ShowColumns(
-                    node.getLocation().get(),
-                    table.getName(),
-                    Optional.empty(),
-                    Optional.empty());
-        }
-        return new ShowColumns(table.getName(), Optional.empty(), Optional.empty());
-    }
-
-    @Override
-    protected Node visitJoin(Join node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Join(
-                    node.getLocation().get(),
-                    node.getType(),
-                    visitAndCast(node.getLeft(), context),
-                    visitAndCast(node.getRight(), context),
-                    node.getCriteria().map(joinCriteria -> visitJoinCriteria(joinCriteria, context)));
-        }
-        return new Join(
-                node.getType(),
-                visitAndCast(node.getLeft(), context),
-                visitAndCast(node.getRight(), context),
-                node.getCriteria().map(joinCriteria -> visitJoinCriteria(joinCriteria, context)));
-    }
-
-    protected JoinCriteria visitJoinCriteria(JoinCriteria joinCriteria, T context)
-    {
-        if (joinCriteria instanceof JoinOn) {
-            JoinOn joinOn = (JoinOn) joinCriteria;
-            return new JoinOn(visitAndCast(joinOn.getExpression(), context));
-        }
-
-        return joinCriteria;
-    }
-
-    @Override
-    protected Node visitAliasedRelation(AliasedRelation node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new AliasedRelation(
-                    node.getLocation().get(),
-                    visitAndCast(node.getRelation(), context),
-                    node.getAlias(),
-                    node.getColumnNames());
-        }
-        return new AliasedRelation(
-                visitAndCast(node.getRelation(), context),
-                node.getAlias(),
-                node.getColumnNames());
-    }
-
-    @Override
     protected Node visitSubqueryExpression(SubqueryExpression node, T context)
     {
         if (node.getLocation().isPresent()) {
@@ -1559,194 +615,12 @@ public class BaseRewriter<T>
     }
 
     @Override
-    protected Node visitTableSubquery(TableSubquery node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new TableSubquery(
-                    node.getLocation().get(),
-                    visitAndCast(node.getQuery(), context));
-        }
-        return new TableSubquery(visitAndCast(node.getQuery(), context));
-    }
-
-    @Override
-    protected Node visitWith(With node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new With(
-                    node.getLocation().get(),
-                    node.isRecursive(),
-                    visitNodes(node.getQueries(), context));
-        }
-        return new With(
-                node.isRecursive(),
-                visitNodes(node.getQueries(), context));
-    }
-
-    @Override
-    protected Node visitWithQuery(WithQuery node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new WithQuery(
-                    node.getLocation().get(),
-                    node.getName(),
-                    visitAndCast(node.getQuery(), context),
-                    node.getColumnNames());
-        }
-        return new WithQuery(
-                node.getName(),
-                visitAndCast(node.getQuery(), context),
-                node.getColumnNames());
-    }
-
-    @Override
-    protected Node visitUnion(Union node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Union(
-                    node.getLocation().get(),
-                    visitNodes(node.getRelations(), context),
-                    node.isDistinct());
-        }
-        return new Union(
-                visitNodes(node.getRelations(), context),
-                node.isDistinct());
-    }
-
-    @Override
-    protected Node visitSelect(Select node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Select(
-                    node.getLocation().get(),
-                    node.isDistinct(),
-                    visitNodes(node.getSelectItems(), context));
-        }
-        return new Select(
-                node.isDistinct(),
-                visitNodes(node.getSelectItems(), context));
-    }
-
-    @Override
-    protected Node visitGroupBy(GroupBy node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new GroupBy(
-                    node.getLocation().get(),
-                    node.isDistinct(),
-                    visitNodes(node.getGroupingElements(), context));
-        }
-        return new GroupBy(node.isDistinct(), visitNodes(node.getGroupingElements(), context));
-    }
-
-    @Override
-    protected Node visitCube(Cube node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Cube(
-                    node.getLocation().get(),
-                    visitNodes(node.getExpressions(), context));
-        }
-        return new Cube(visitNodes(node.getExpressions(), context));
-    }
-
-    @Override
-    protected Node visitGroupingSets(GroupingSets node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new GroupingSets(
-                    node.getLocation().get(),
-                    node.getSets().stream()
-                            .map(expressions -> visitNodes(expressions, context))
-                            .collect(toList()));
-        }
-        return new GroupingSets(
-                node.getSets().stream()
-                        .map(expressions -> visitNodes(expressions, context))
-                        .collect(toList()));
-    }
-
-    @Override
-    protected Node visitSimpleGroupBy(SimpleGroupBy node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new SimpleGroupBy(
-                    node.getLocation().get(),
-                    visitNodes(node.getExpressions(), context));
-        }
-        return new SimpleGroupBy(visitNodes(node.getExpressions(), context));
-    }
-
-    @Override
-    protected Node visitRollup(Rollup node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Rollup(
-                    node.getLocation().get(),
-                    visitNodes(node.getExpressions(), context));
-        }
-        return new Rollup(visitNodes(node.getExpressions(), context));
-    }
-
-    @Override
-    protected Node visitOrderBy(OrderBy node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new OrderBy(
-                    node.getLocation().get(),
-                    visitNodes(node.getSortItems(), context));
-        }
-        return new OrderBy(visitNodes(node.getSortItems(), context));
-    }
-
-    @Override
-    protected Node visitSortItem(SortItem node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new SortItem(
-                    node.getLocation().get(),
-                    visitAndCast(node.getSortKey(), context),
-                    node.getOrdering(),
-                    node.getNullOrdering());
-        }
-        return new SortItem(
-                visitAndCast(node.getSortKey(), context),
-                node.getOrdering(),
-                node.getNullOrdering());
-    }
-
-    @Override
-    protected Node visitSingleColumn(SingleColumn node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new SingleColumn(
-                    node.getLocation().get(),
-                    visitAndCast(node.getExpression(), context),
-                    node.getAlias());
-        }
-        return new SingleColumn(
-                visitAndCast(node.getExpression(), context),
-                node.getAlias());
-    }
-
-    @Override
     protected Node visitDereferenceExpression(DereferenceExpression node, T context)
     {
         return new DereferenceExpression(
                 node.getLocation(),
                 visitAndCast(node.getBase(), context),
                 node.getField());
-    }
-
-    @Override
-    protected Node visitTable(Table node, T context)
-    {
-        if (node.getLocation().isPresent()) {
-            return new Table(
-                    node.getLocation().get(),
-                    node.getName());
-        }
-        return new Table(node.getName());
     }
 
     protected <S extends Node> S visitAndCast(S node, T context)

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/BaseTreeRewriter.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/BaseTreeRewriter.java
@@ -1,0 +1,1197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite;
+
+import io.trino.sql.tree.AddColumn;
+import io.trino.sql.tree.AliasedRelation;
+import io.trino.sql.tree.AllColumns;
+import io.trino.sql.tree.Analyze;
+import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.AtTimeZone;
+import io.trino.sql.tree.Call;
+import io.trino.sql.tree.CallArgument;
+import io.trino.sql.tree.ColumnDefinition;
+import io.trino.sql.tree.Comment;
+import io.trino.sql.tree.Commit;
+import io.trino.sql.tree.CreateRole;
+import io.trino.sql.tree.CreateSchema;
+import io.trino.sql.tree.CreateTable;
+import io.trino.sql.tree.CreateTableAsSelect;
+import io.trino.sql.tree.CreateView;
+import io.trino.sql.tree.Cube;
+import io.trino.sql.tree.CurrentPath;
+import io.trino.sql.tree.CurrentTime;
+import io.trino.sql.tree.CurrentUser;
+import io.trino.sql.tree.Deallocate;
+import io.trino.sql.tree.Delete;
+import io.trino.sql.tree.DescribeInput;
+import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.DropColumn;
+import io.trino.sql.tree.DropRole;
+import io.trino.sql.tree.DropSchema;
+import io.trino.sql.tree.DropTable;
+import io.trino.sql.tree.DropView;
+import io.trino.sql.tree.Except;
+import io.trino.sql.tree.Execute;
+import io.trino.sql.tree.Explain;
+import io.trino.sql.tree.ExplainOption;
+import io.trino.sql.tree.Extract;
+import io.trino.sql.tree.FetchFirst;
+import io.trino.sql.tree.Format;
+import io.trino.sql.tree.FrameBound;
+import io.trino.sql.tree.FunctionRelation;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Grant;
+import io.trino.sql.tree.GrantRoles;
+import io.trino.sql.tree.GroupBy;
+import io.trino.sql.tree.GroupingElement;
+import io.trino.sql.tree.GroupingOperation;
+import io.trino.sql.tree.GroupingSets;
+import io.trino.sql.tree.Insert;
+import io.trino.sql.tree.Intersect;
+import io.trino.sql.tree.Isolation;
+import io.trino.sql.tree.Join;
+import io.trino.sql.tree.JoinCriteria;
+import io.trino.sql.tree.JoinOn;
+import io.trino.sql.tree.Lateral;
+import io.trino.sql.tree.LikeClause;
+import io.trino.sql.tree.Limit;
+import io.trino.sql.tree.Node;
+import io.trino.sql.tree.Offset;
+import io.trino.sql.tree.OrderBy;
+import io.trino.sql.tree.PathElement;
+import io.trino.sql.tree.PathSpecification;
+import io.trino.sql.tree.Prepare;
+import io.trino.sql.tree.Property;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.QueryBody;
+import io.trino.sql.tree.QuerySpecification;
+import io.trino.sql.tree.Relation;
+import io.trino.sql.tree.RenameColumn;
+import io.trino.sql.tree.RenameSchema;
+import io.trino.sql.tree.RenameTable;
+import io.trino.sql.tree.ResetSession;
+import io.trino.sql.tree.Revoke;
+import io.trino.sql.tree.RevokeRoles;
+import io.trino.sql.tree.Rollback;
+import io.trino.sql.tree.Rollup;
+import io.trino.sql.tree.SampledRelation;
+import io.trino.sql.tree.Select;
+import io.trino.sql.tree.SelectItem;
+import io.trino.sql.tree.SetOperation;
+import io.trino.sql.tree.SetPath;
+import io.trino.sql.tree.SetRole;
+import io.trino.sql.tree.SetSession;
+import io.trino.sql.tree.ShowCatalogs;
+import io.trino.sql.tree.ShowColumns;
+import io.trino.sql.tree.ShowCreate;
+import io.trino.sql.tree.ShowFunctions;
+import io.trino.sql.tree.ShowGrants;
+import io.trino.sql.tree.ShowRoleGrants;
+import io.trino.sql.tree.ShowRoles;
+import io.trino.sql.tree.ShowSchemas;
+import io.trino.sql.tree.ShowSession;
+import io.trino.sql.tree.ShowStats;
+import io.trino.sql.tree.ShowTables;
+import io.trino.sql.tree.SimpleGroupBy;
+import io.trino.sql.tree.SingleColumn;
+import io.trino.sql.tree.SortItem;
+import io.trino.sql.tree.StartTransaction;
+import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.SymbolReference;
+import io.trino.sql.tree.Table;
+import io.trino.sql.tree.TableElement;
+import io.trino.sql.tree.TableSubquery;
+import io.trino.sql.tree.TimeLiteral;
+import io.trino.sql.tree.TransactionAccessMode;
+import io.trino.sql.tree.TransactionMode;
+import io.trino.sql.tree.Union;
+import io.trino.sql.tree.Unnest;
+import io.trino.sql.tree.Use;
+import io.trino.sql.tree.Values;
+import io.trino.sql.tree.Window;
+import io.trino.sql.tree.WindowFrame;
+import io.trino.sql.tree.WindowReference;
+import io.trino.sql.tree.WindowSpecification;
+import io.trino.sql.tree.With;
+import io.trino.sql.tree.WithQuery;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Base class for tree rewriter. It will traverse all query nodes excludes all expressions, literals and data type parameters.
+ */
+public class BaseTreeRewriter<T>
+        extends AstVisitor<Node, T>
+{
+    @Override
+    protected Node visitNode(Node node, T context)
+    {
+        return node;
+    }
+
+    @Override
+    protected Node visitCreateTableAsSelect(CreateTableAsSelect node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new CreateTableAsSelect(
+                    node.getLocation().get(),
+                    node.getName(),
+                    visitAndCast(node.getQuery(), context),
+                    node.isNotExists(),
+                    node.getProperties(),
+                    node.isWithData(),
+                    node.getColumnAliases(),
+                    node.getComment());
+        }
+        return new CreateTableAsSelect(
+                node.getName(),
+                visitAndCast(node.getQuery(), context),
+                node.isNotExists(),
+                node.getProperties(),
+                node.isWithData(),
+                node.getColumnAliases(),
+                node.getComment());
+    }
+
+    @Override
+    protected Node visitQuery(Query node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Query(
+                    node.getLocation().get(),
+                    node.getWith().map(expression -> visitAndCast(expression, context)),
+                    visitAndCast(node.getQueryBody(), context),
+                    node.getOrderBy().map(expression -> visitAndCast(expression, context)),
+                    node.getOffset(),
+                    node.getLimit());
+        }
+        return new Query(
+                node.getWith().map(expression -> visitAndCast(expression, context)),
+                visitAndCast(node.getQueryBody(), context),
+                node.getOrderBy().map(expression -> visitAndCast(expression, context)),
+                node.getOffset(),
+                node.getLimit());
+    }
+
+    @Override
+    protected Node visitCurrentTime(CurrentTime node, T context)
+    {
+        return super.visitCurrentTime(node, context);
+    }
+
+    @Override
+    protected Node visitExtract(Extract node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            new Extract(
+                    node.getLocation().get(),
+                    visitAndCast(node.getExpression(), context),
+                    node.getField());
+        }
+        return new Extract(visitAndCast(node.getExpression(), context), node.getField());
+    }
+
+    @Override
+    protected Node visitStatement(Statement node, T context)
+    {
+        return super.visitStatement(node, context);
+    }
+
+    @Override
+    protected Node visitPrepare(Prepare node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Prepare(
+                    node.getLocation().get(),
+                    node.getName(),
+                    visitAndCast(node.getStatement(), context));
+        }
+        return new Prepare(
+                node.getName(),
+                visitAndCast(node.getStatement(), context));
+    }
+
+    @Override
+    protected Node visitDeallocate(Deallocate node, T context)
+    {
+        return super.visitDeallocate(node, context);
+    }
+
+    @Override
+    protected Node visitExecute(Execute node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Execute(
+                    node.getLocation().get(),
+                    node.getName(),
+                    visitNodes(node.getParameters(), context));
+        }
+        return new Execute(node.getName(), visitNodes(node.getParameters(), context));
+    }
+
+    @Override
+    protected Node visitDescribeOutput(DescribeOutput node, T context)
+    {
+        return super.visitDescribeOutput(node, context);
+    }
+
+    @Override
+    protected Node visitDescribeInput(DescribeInput node, T context)
+    {
+        return super.visitDescribeInput(node, context);
+    }
+
+    @Override
+    protected Node visitExplain(Explain node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Explain(
+                    node.getLocation().get(),
+                    visitAndCast(node.getStatement(), context),
+                    node.getOptions());
+        }
+        return new Explain(
+                visitAndCast(node.getStatement(), context),
+                node.getOptions());
+    }
+
+    @Override
+    protected Node visitShowTables(ShowTables node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new ShowTables(
+                    node.getLocation().get(),
+                    node.getSchema(),
+                    node.getLikePattern(),
+                    node.getEscape());
+        }
+        return new ShowTables(
+                node.getSchema(),
+                node.getLikePattern(),
+                node.getEscape());
+    }
+
+    @Override
+    protected Node visitShowSchemas(ShowSchemas node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new ShowSchemas(
+                    node.getLocation().get(),
+                    node.getCatalog(),
+                    node.getLikePattern(),
+                    node.getEscape());
+        }
+        return new ShowSchemas(
+                node.getCatalog(),
+                node.getLikePattern(),
+                node.getEscape());
+    }
+
+    @Override
+    protected Node visitShowCatalogs(ShowCatalogs node, T context)
+    {
+        return super.visitShowCatalogs(node, context);
+    }
+
+    @Override
+    protected Node visitShowStats(ShowStats node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new ShowStats(
+                    node.getLocation(),
+                    visitAndCast(node.getRelation(), context));
+        }
+        return new ShowStats(visitAndCast(node.getRelation(), context));
+    }
+
+    @Override
+    protected Node visitShowCreate(ShowCreate node, T context)
+    {
+        if (node.getType() == ShowCreate.Type.TABLE) {
+            Table table = (Table) visitTable(new Table(node.getName()), context);
+            if (node.getLocation().isPresent()) {
+                return new ShowCreate(
+                        node.getLocation().get(),
+                        node.getType(),
+                        table.getName());
+            }
+            return new ShowCreate(
+                    node.getType(),
+                    table.getName());
+        }
+        return super.visitShowCreate(node, context);
+    }
+
+    @Override
+    protected Node visitShowFunctions(ShowFunctions node, T context)
+    {
+        return super.visitShowFunctions(node, context);
+    }
+
+    @Override
+    protected Node visitUse(Use node, T context)
+    {
+        return super.visitUse(node, context);
+    }
+
+    @Override
+    protected Node visitShowSession(ShowSession node, T context)
+    {
+        return super.visitShowSession(node, context);
+    }
+
+    @Override
+    protected Node visitSetSession(SetSession node, T context)
+    {
+        return super.visitSetSession(node, context);
+    }
+
+    @Override
+    protected Node visitResetSession(ResetSession node, T context)
+    {
+        return super.visitResetSession(node, context);
+    }
+
+    @Override
+    protected Node visitGenericLiteral(GenericLiteral node, T context)
+    {
+        return super.visitGenericLiteral(node, context);
+    }
+
+    @Override
+    protected Node visitTimeLiteral(TimeLiteral node, T context)
+    {
+        return super.visitTimeLiteral(node, context);
+    }
+
+    @Override
+    protected Node visitExplainOption(ExplainOption node, T context)
+    {
+        return super.visitExplainOption(node, context);
+    }
+
+    @Override
+    protected Node visitRelation(Relation node, T context)
+    {
+        return super.visitRelation(node, context);
+    }
+
+    @Override
+    protected Node visitQueryBody(QueryBody node, T context)
+    {
+        return super.visitQueryBody(node, context);
+    }
+
+    @Override
+    protected Node visitOffset(Offset node, T context)
+    {
+        return super.visitOffset(node, context);
+    }
+
+    @Override
+    protected Node visitFetchFirst(FetchFirst node, T context)
+    {
+        return super.visitFetchFirst(node, context);
+    }
+
+    @Override
+    protected Node visitLimit(Limit node, T context)
+    {
+        return super.visitLimit(node, context);
+    }
+
+    @Override
+    protected Node visitSetOperation(SetOperation node, T context)
+    {
+        return super.visitSetOperation(node, context);
+    }
+
+    @Override
+    protected Node visitIntersect(Intersect node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Intersect(
+                    node.getLocation().get(),
+                    visitNodes(node.getRelations(), context),
+                    node.isDistinct());
+        }
+        return new Intersect(visitNodes(node.getRelations(), context), node.isDistinct());
+    }
+
+    @Override
+    protected Node visitExcept(Except node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Except(
+                    node.getLocation().get(),
+                    visitAndCast(node.getLeft(), context),
+                    visitAndCast(node.getRight(), context),
+                    node.isDistinct());
+        }
+        return new Except(
+                visitAndCast(node.getLeft(), context),
+                visitAndCast(node.getRight(), context),
+                node.isDistinct());
+    }
+
+    @Override
+    protected Node visitSelectItem(SelectItem node, T context)
+    {
+        return super.visitSelectItem(node, context);
+    }
+
+    @Override
+    protected Node visitAllColumns(AllColumns node, T context)
+    {
+        return super.visitAllColumns(node, context);
+    }
+
+    @Override
+    protected Node visitUnnest(Unnest node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Unnest(
+                    node.getLocation().get(),
+                    visitNodes(node.getExpressions(), context),
+                    node.isWithOrdinality());
+        }
+        return new Unnest(visitNodes(node.getExpressions(), context), node.isWithOrdinality());
+    }
+
+    @Override
+    protected Node visitFunctionRelation(FunctionRelation node, T context)
+    {
+        return new FunctionRelation(
+                node.getLocation().orElse(null),
+                node.getName(),
+                node.getArguments());
+    }
+
+    @Override
+    protected Node visitLateral(Lateral node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Lateral(
+                    node.getLocation().get(),
+                    visitAndCast(node.getQuery(), context));
+        }
+        return new Lateral(visitAndCast(node.getQuery(), context));
+    }
+
+    @Override
+    protected Node visitValues(Values node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Values(
+                    node.getLocation().get(),
+                    visitNodes(node.getRows(), context));
+        }
+        return new Values(visitNodes(node.getRows(), context));
+    }
+
+    @Override
+    protected Node visitSampledRelation(SampledRelation node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new SampledRelation(
+                    node.getLocation().get(),
+                    visitAndCast(node.getRelation(), context),
+                    node.getType(),
+                    visitAndCast(node.getSamplePercentage(), context));
+        }
+        return new SampledRelation(
+                visitAndCast(node.getRelation(), context),
+                node.getType(),
+                visitAndCast(node.getSamplePercentage(), context));
+    }
+
+    @Override
+    protected Node visitWindowSpecification(WindowSpecification node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new WindowSpecification(
+                    node.getLocation().get(),
+                    node.getExistingWindowName(),
+                    visitNodes(node.getPartitionBy(), context),
+                    node.getOrderBy(),
+                    node.getFrame().map(expression -> visitAndCast(expression, context)));
+        }
+        return new WindowSpecification(
+                node.getExistingWindowName(),
+                visitNodes(node.getPartitionBy(), context),
+                node.getOrderBy(),
+                node.getFrame().map(expression -> visitAndCast(expression, context)));
+    }
+
+    @Override
+    protected Node visitWindowFrame(WindowFrame node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new WindowFrame(
+                    node.getLocation().get(),
+                    node.getType(),
+                    visitAndCast(node.getStart(), context),
+                    node.getEnd().map(expression -> visitAndCast(expression, context)),
+                    node.getMeasures(),
+                    node.getAfterMatchSkipTo(),
+                    node.getPatternSearchMode(),
+                    node.getPattern(),
+                    node.getSubsets(),
+                    node.getVariableDefinitions());
+        }
+        return new WindowFrame(
+                node.getType(),
+                visitAndCast(node.getStart(), context),
+                node.getEnd().map(expression -> visitAndCast(expression, context)),
+                node.getMeasures(),
+                node.getAfterMatchSkipTo(),
+                node.getPatternSearchMode(),
+                node.getPattern(),
+                node.getSubsets(),
+                node.getVariableDefinitions());
+    }
+
+    @Override
+    protected Node visitFrameBound(FrameBound node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new FrameBound(
+                    node.getLocation().get(),
+                    node.getType(),
+                    node.getValue().map(expression -> visitAndCast(expression, context)).orElse(null));
+        }
+        return new FrameBound(
+                node.getType(),
+                node.getValue().map(expression -> visitAndCast(expression, context)).orElse(null));
+    }
+
+    @Override
+    protected Node visitCallArgument(CallArgument node, T context)
+    {
+        return new CallArgument(
+                node.getLocation(),
+                node.getName(),
+                visitAndCast(node.getValue(), context));
+    }
+
+    @Override
+    protected Node visitTableElement(TableElement node, T context)
+    {
+        return super.visitTableElement(node, context);
+    }
+
+    @Override
+    protected Node visitColumnDefinition(ColumnDefinition node, T context)
+    {
+        return super.visitColumnDefinition(node, context);
+    }
+
+    @Override
+    protected Node visitLikeClause(LikeClause node, T context)
+    {
+        return super.visitLikeClause(node, context);
+    }
+
+    @Override
+    protected Node visitCreateSchema(CreateSchema node, T context)
+    {
+        return super.visitCreateSchema(node, context);
+    }
+
+    @Override
+    protected Node visitDropSchema(DropSchema node, T context)
+    {
+        return super.visitDropSchema(node, context);
+    }
+
+    @Override
+    protected Node visitRenameSchema(RenameSchema node, T context)
+    {
+        return super.visitRenameSchema(node, context);
+    }
+
+    @Override
+    protected Node visitCreateTable(CreateTable node, T context)
+    {
+        return super.visitCreateTable(node, context);
+    }
+
+    @Override
+    protected Node visitProperty(Property node, T context)
+    {
+        return super.visitProperty(node, context);
+    }
+
+    @Override
+    protected Node visitDropTable(DropTable node, T context)
+    {
+        return super.visitDropTable(node, context);
+    }
+
+    @Override
+    protected Node visitRenameTable(RenameTable node, T context)
+    {
+        return super.visitRenameTable(node, context);
+    }
+
+    @Override
+    protected Node visitComment(Comment node, T context)
+    {
+        return super.visitComment(node, context);
+    }
+
+    @Override
+    protected Node visitRenameColumn(RenameColumn node, T context)
+    {
+        return super.visitRenameColumn(node, context);
+    }
+
+    @Override
+    protected Node visitDropColumn(DropColumn node, T context)
+    {
+        return super.visitDropColumn(node, context);
+    }
+
+    @Override
+    protected Node visitAddColumn(AddColumn node, T context)
+    {
+        return super.visitAddColumn(node, context);
+    }
+
+    @Override
+    protected Node visitAnalyze(Analyze node, T context)
+    {
+        return super.visitAnalyze(node, context);
+    }
+
+    @Override
+    protected Node visitCreateView(CreateView node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new CreateView(
+                    node.getLocation().get(),
+                    node.getName(),
+                    visitAndCast(node.getQuery(), context),
+                    node.isReplace(),
+                    node.getComment(),
+                    node.getSecurity());
+        }
+        return new CreateView(
+                node.getName(),
+                visitAndCast(node.getQuery(), context),
+                node.isReplace(),
+                node.getComment(),
+                node.getSecurity());
+    }
+
+    @Override
+    protected Node visitDropView(DropView node, T context)
+    {
+        return super.visitDropView(node, context);
+    }
+
+    @Override
+    protected Node visitInsert(Insert node, T context)
+    {
+        return super.visitInsert(node, context);
+    }
+
+    @Override
+    protected Node visitCall(Call node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Call(
+                    node.getLocation().get(),
+                    node.getName(),
+                    visitNodes(node.getArguments(), context));
+        }
+        return new Call(node.getName(), visitNodes(node.getArguments(), context));
+    }
+
+    @Override
+    protected Node visitDelete(Delete node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Delete(
+                    node.getLocation().get(),
+                    visitAndCast(node.getTable(), context),
+                    node.getWhere().map(expression -> visitAndCast(expression, context)));
+        }
+        return new Delete(
+                visitAndCast(node.getTable(), context),
+                node.getWhere().map(expression -> visitAndCast(expression, context)));
+    }
+
+    @Override
+    protected Node visitStartTransaction(StartTransaction node, T context)
+    {
+        return super.visitStartTransaction(node, context);
+    }
+
+    @Override
+    protected Node visitCreateRole(CreateRole node, T context)
+    {
+        return super.visitCreateRole(node, context);
+    }
+
+    @Override
+    protected Node visitDropRole(DropRole node, T context)
+    {
+        return super.visitDropRole(node, context);
+    }
+
+    @Override
+    protected Node visitGrantRoles(GrantRoles node, T context)
+    {
+        return super.visitGrantRoles(node, context);
+    }
+
+    @Override
+    protected Node visitRevokeRoles(RevokeRoles node, T context)
+    {
+        return super.visitRevokeRoles(node, context);
+    }
+
+    @Override
+    protected Node visitSetRole(SetRole node, T context)
+    {
+        return super.visitSetRole(node, context);
+    }
+
+    @Override
+    protected Node visitGrant(Grant node, T context)
+    {
+        return super.visitGrant(node, context);
+    }
+
+    @Override
+    protected Node visitRevoke(Revoke node, T context)
+    {
+        return super.visitRevoke(node, context);
+    }
+
+    @Override
+    protected Node visitShowGrants(ShowGrants node, T context)
+    {
+        return super.visitShowGrants(node, context);
+    }
+
+    @Override
+    protected Node visitShowRoles(ShowRoles node, T context)
+    {
+        return super.visitShowRoles(node, context);
+    }
+
+    @Override
+    protected Node visitShowRoleGrants(ShowRoleGrants node, T context)
+    {
+        return super.visitShowRoleGrants(node, context);
+    }
+
+    @Override
+    protected Node visitSetPath(SetPath node, T context)
+    {
+        return super.visitSetPath(node, context);
+    }
+
+    @Override
+    protected Node visitPathSpecification(PathSpecification node, T context)
+    {
+        return super.visitPathSpecification(node, context);
+    }
+
+    @Override
+    protected Node visitPathElement(PathElement node, T context)
+    {
+        return super.visitPathElement(node, context);
+    }
+
+    @Override
+    protected Node visitTransactionMode(TransactionMode node, T context)
+    {
+        return super.visitTransactionMode(node, context);
+    }
+
+    @Override
+    protected Node visitIsolationLevel(Isolation node, T context)
+    {
+        return super.visitIsolationLevel(node, context);
+    }
+
+    @Override
+    protected Node visitTransactionAccessMode(TransactionAccessMode node, T context)
+    {
+        return super.visitTransactionAccessMode(node, context);
+    }
+
+    @Override
+    protected Node visitCommit(Commit node, T context)
+    {
+        return super.visitCommit(node, context);
+    }
+
+    @Override
+    protected Node visitRollback(Rollback node, T context)
+    {
+        return super.visitRollback(node, context);
+    }
+
+    @Override
+    protected Node visitAtTimeZone(AtTimeZone node, T context)
+    {
+        return super.visitAtTimeZone(node, context);
+    }
+
+    @Override
+    protected Node visitGroupingElement(GroupingElement node, T context)
+    {
+        return super.visitGroupingElement(node, context);
+    }
+
+    @Override
+    protected Node visitSymbolReference(SymbolReference node, T context)
+    {
+        return super.visitSymbolReference(node, context);
+    }
+
+    @Override
+    protected Node visitGroupingOperation(GroupingOperation node, T context)
+    {
+        return super.visitGroupingOperation(node, context);
+    }
+
+    @Override
+    protected Node visitCurrentUser(CurrentUser node, T context)
+    {
+        return super.visitCurrentUser(node, context);
+    }
+
+    @Override
+    protected Node visitCurrentPath(CurrentPath node, T context)
+    {
+        return super.visitCurrentPath(node, context);
+    }
+
+    @Override
+    protected Node visitFormat(Format node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Format(
+                    node.getLocation().get(),
+                    visitNodes(node.getArguments(), context));
+        }
+        return new Format(visitNodes(node.getArguments(), context));
+    }
+
+    @Override
+    protected Node visitQuerySpecification(QuerySpecification node, T context)
+    {
+        // Relations should be visited first for alias.
+        Optional<Relation> from = node.getFrom().map(expression -> visitAndCast(expression, context));
+
+        if (node.getLocation().isPresent()) {
+            return new QuerySpecification(
+                    node.getLocation().get(),
+                    visitAndCast(node.getSelect(), context),
+                    from,
+                    node.getWhere().map(expression -> visitAndCast(expression, context)),
+                    node.getGroupBy().map(expression -> visitAndCast(expression, context)),
+                    node.getHaving().map(expression -> visitAndCast(expression, context)),
+                    visitNodes(node.getWindows(), context),
+                    node.getOrderBy().map(expression -> visitAndCast(expression, context)),
+                    node.getOffset(),
+                    node.getLimit());
+        }
+        return new QuerySpecification(
+                visitAndCast(node.getSelect(), context),
+                from,
+                node.getWhere().map(expression -> visitAndCast(expression, context)),
+                node.getGroupBy().map(expression -> visitAndCast(expression, context)),
+                node.getHaving().map(expression -> visitAndCast(expression, context)),
+                visitNodes(node.getWindows(), context),
+                node.getOrderBy().map(expression -> visitAndCast(expression, context)),
+                node.getOffset(),
+                node.getLimit());
+    }
+
+    @Override
+    protected Node visitShowColumns(ShowColumns node, T context)
+    {
+        Table table = (Table) visitTable(new Table(node.getTable()), context);
+        if (node.getLocation().isPresent()) {
+            return new ShowColumns(
+                    node.getLocation().get(),
+                    table.getName(),
+                    Optional.empty(),
+                    Optional.empty());
+        }
+        return new ShowColumns(table.getName(), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    protected Node visitJoin(Join node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Join(
+                    node.getLocation().get(),
+                    node.getType(),
+                    visitAndCast(node.getLeft(), context),
+                    visitAndCast(node.getRight(), context),
+                    node.getCriteria().map(joinCriteria -> visitJoinCriteria(joinCriteria, context)));
+        }
+        return new Join(
+                node.getType(),
+                visitAndCast(node.getLeft(), context),
+                visitAndCast(node.getRight(), context),
+                node.getCriteria().map(joinCriteria -> visitJoinCriteria(joinCriteria, context)));
+    }
+
+    protected JoinCriteria visitJoinCriteria(JoinCriteria joinCriteria, T context)
+    {
+        if (joinCriteria instanceof JoinOn) {
+            JoinOn joinOn = (JoinOn) joinCriteria;
+            return new JoinOn(visitAndCast(joinOn.getExpression(), context));
+        }
+
+        return joinCriteria;
+    }
+
+    @Override
+    protected Node visitAliasedRelation(AliasedRelation node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new AliasedRelation(
+                    node.getLocation().get(),
+                    visitAndCast(node.getRelation(), context),
+                    node.getAlias(),
+                    node.getColumnNames());
+        }
+        return new AliasedRelation(
+                visitAndCast(node.getRelation(), context),
+                node.getAlias(),
+                node.getColumnNames());
+    }
+
+    @Override
+    protected Node visitTableSubquery(TableSubquery node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new TableSubquery(
+                    node.getLocation().get(),
+                    visitAndCast(node.getQuery(), context));
+        }
+        return new TableSubquery(visitAndCast(node.getQuery(), context));
+    }
+
+    @Override
+    protected Node visitWith(With node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new With(
+                    node.getLocation().get(),
+                    node.isRecursive(),
+                    visitNodes(node.getQueries(), context));
+        }
+        return new With(
+                node.isRecursive(),
+                visitNodes(node.getQueries(), context));
+    }
+
+    @Override
+    protected Node visitWithQuery(WithQuery node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new WithQuery(
+                    node.getLocation().get(),
+                    node.getName(),
+                    visitAndCast(node.getQuery(), context),
+                    node.getColumnNames());
+        }
+        return new WithQuery(
+                node.getName(),
+                visitAndCast(node.getQuery(), context),
+                node.getColumnNames());
+    }
+
+    @Override
+    protected Node visitUnion(Union node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Union(
+                    node.getLocation().get(),
+                    visitNodes(node.getRelations(), context),
+                    node.isDistinct());
+        }
+        return new Union(
+                visitNodes(node.getRelations(), context),
+                node.isDistinct());
+    }
+
+    @Override
+    protected Node visitSelect(Select node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Select(
+                    node.getLocation().get(),
+                    node.isDistinct(),
+                    visitNodes(node.getSelectItems(), context));
+        }
+        return new Select(
+                node.isDistinct(),
+                visitNodes(node.getSelectItems(), context));
+    }
+
+    @Override
+    protected Node visitGroupBy(GroupBy node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new GroupBy(
+                    node.getLocation().get(),
+                    node.isDistinct(),
+                    visitNodes(node.getGroupingElements(), context));
+        }
+        return new GroupBy(node.isDistinct(), visitNodes(node.getGroupingElements(), context));
+    }
+
+    @Override
+    protected Node visitCube(Cube node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Cube(
+                    node.getLocation().get(),
+                    visitNodes(node.getExpressions(), context));
+        }
+        return new Cube(visitNodes(node.getExpressions(), context));
+    }
+
+    @Override
+    protected Node visitGroupingSets(GroupingSets node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new GroupingSets(
+                    node.getLocation().get(),
+                    node.getSets().stream()
+                            .map(expressions -> visitNodes(expressions, context))
+                            .collect(toList()));
+        }
+        return new GroupingSets(
+                node.getSets().stream()
+                        .map(expressions -> visitNodes(expressions, context))
+                        .collect(toList()));
+    }
+
+    @Override
+    protected Node visitSimpleGroupBy(SimpleGroupBy node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new SimpleGroupBy(
+                    node.getLocation().get(),
+                    visitNodes(node.getExpressions(), context));
+        }
+        return new SimpleGroupBy(visitNodes(node.getExpressions(), context));
+    }
+
+    @Override
+    protected Node visitRollup(Rollup node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Rollup(
+                    node.getLocation().get(),
+                    visitNodes(node.getExpressions(), context));
+        }
+        return new Rollup(visitNodes(node.getExpressions(), context));
+    }
+
+    @Override
+    protected Node visitOrderBy(OrderBy node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new OrderBy(
+                    node.getLocation().get(),
+                    visitNodes(node.getSortItems(), context));
+        }
+        return new OrderBy(visitNodes(node.getSortItems(), context));
+    }
+
+    @Override
+    protected Node visitSortItem(SortItem node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new SortItem(
+                    node.getLocation().get(),
+                    visitAndCast(node.getSortKey(), context),
+                    node.getOrdering(),
+                    node.getNullOrdering());
+        }
+        return new SortItem(
+                visitAndCast(node.getSortKey(), context),
+                node.getOrdering(),
+                node.getNullOrdering());
+    }
+
+    @Override
+    protected Node visitSingleColumn(SingleColumn node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new SingleColumn(
+                    node.getLocation().get(),
+                    visitAndCast(node.getExpression(), context),
+                    node.getAlias());
+        }
+        return new SingleColumn(
+                visitAndCast(node.getExpression(), context),
+                node.getAlias());
+    }
+
+    @Override
+    protected Node visitTable(Table node, T context)
+    {
+        if (node.getLocation().isPresent()) {
+            return new Table(
+                    node.getLocation().get(),
+                    node.getName());
+        }
+        return new Table(node.getName());
+    }
+
+    protected <S extends Node> S visitAndCast(S node, T context)
+    {
+        return (S) process(node, context);
+    }
+
+    protected <S extends Window> S visitAndCast(S window, T context)
+    {
+        Node node = null;
+        if (window instanceof WindowSpecification) {
+            node = (WindowSpecification) window;
+        }
+        else if (window instanceof WindowReference) {
+            node = (WindowReference) window;
+        }
+        return (S) process(node, context);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <S extends Node> List<S> visitNodes(List<S> nodes, T context)
+    {
+        return nodes.stream()
+                .map(node -> (S) process(node, context))
+                .collect(toList());
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/MetricRollupRewrite.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/MetricRollupRewrite.java
@@ -40,7 +40,9 @@ public class MetricRollupRewrite
     @Override
     public Statement apply(Statement root, SessionContext sessionContext, AnalyzedMDL analyzedMDL)
     {
-        return apply(root, sessionContext, StatementAnalyzer.analyze(root, sessionContext, analyzedMDL.getAccioMDL()), analyzedMDL);
+        Analysis analysis = new Analysis(root);
+        StatementAnalyzer.analyze(analysis, root, sessionContext, analyzedMDL.getAccioMDL());
+        return apply(root, sessionContext, analysis, analyzedMDL);
     }
 
     @Override

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/Utils.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/Utils.java
@@ -281,7 +281,6 @@ public final class Utils
         return Scope.builder()
                 .parent(context)
                 .relationType(new RelationType(fields.build()))
-                .isTableScope(true)
                 .build();
     }
 

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/ViewInfo.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/ViewInfo.java
@@ -36,7 +36,8 @@ public class ViewInfo
     public static ViewInfo get(View view, AnalyzedMDL analyzedMDL, SessionContext sessionContext)
     {
         Query query = parseView(view.getStatement());
-        Analysis analysis = StatementAnalyzer.analyze(query, sessionContext, analyzedMDL.getAccioMDL());
+        Analysis analysis = new Analysis(query);
+        StatementAnalyzer.analyze(analysis, query, sessionContext, analyzedMDL.getAccioMDL());
         // sql in view can use metric rollup syntax
         query = (Query) MetricRollupRewrite.METRIC_ROLLUP_REWRITE.apply(query, sessionContext, analysis, analyzedMDL);
         return new ViewInfo(view.getName(), analysis.getAccioObjectNames(), query);

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
@@ -36,7 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -60,9 +59,8 @@ public class Analysis
     private final List<SimplePredicate> simplePredicates = new ArrayList<>();
 
     private final Map<NodeRef<Node>, Node> typeCoercionMap = new HashMap<>();
-    private Scope queryScope;
 
-    Analysis(Statement statement)
+    public Analysis(Statement statement)
     {
         this.root = requireNonNull(statement, "statement is null");
     }
@@ -185,16 +183,6 @@ public class Analysis
     public Map<NodeRef<Node>, Node> getTypeCoercionMap()
     {
         return typeCoercionMap;
-    }
-
-    public Optional<Scope> getQueryScope()
-    {
-        return Optional.ofNullable(queryScope);
-    }
-
-    public void setQueryScope(Scope queryScope)
-    {
-        this.queryScope = queryScope;
     }
 
     /**

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
@@ -25,6 +25,7 @@ import io.accio.base.dto.Relationship;
 import io.accio.base.dto.View;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionRelation;
+import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.Table;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -56,6 +58,9 @@ public class Analysis
     private final Set<View> views = new HashSet<>();
     private final Multimap<CatalogSchemaTableName, String> collectedColumns = HashMultimap.create();
     private final List<SimplePredicate> simplePredicates = new ArrayList<>();
+
+    private final Map<NodeRef<Node>, Node> typeCoercionMap = new HashMap<>();
+    private Scope queryScope;
 
     Analysis(Statement statement)
     {
@@ -170,6 +175,26 @@ public class Analysis
     public Multimap<CatalogSchemaTableName, String> getCollectedColumns()
     {
         return collectedColumns;
+    }
+
+    void addTypeCoercion(NodeRef<Node> nodeRef, Node node)
+    {
+        typeCoercionMap.put(nodeRef, node);
+    }
+
+    public Map<NodeRef<Node>, Node> getTypeCoercionMap()
+    {
+        return typeCoercionMap;
+    }
+
+    public Optional<Scope> getQueryScope()
+    {
+        return Optional.ofNullable(queryScope);
+    }
+
+    public void setQueryScope(Scope queryScope)
+    {
+        this.queryScope = queryScope;
     }
 
     /**

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionTypeAnalyzer.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionTypeAnalyzer.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite.analyzer;
+
+import com.google.common.collect.ImmutableList;
+import io.accio.base.AccioMDL;
+import io.accio.base.dto.CumulativeMetric;
+import io.accio.base.type.BigIntType;
+import io.accio.base.type.BooleanType;
+import io.accio.base.type.ByteaType;
+import io.accio.base.type.DateType;
+import io.accio.base.type.DoubleType;
+import io.accio.base.type.IntervalType;
+import io.accio.base.type.NumericType;
+import io.accio.base.type.PGType;
+import io.accio.base.type.PGTypes;
+import io.accio.base.type.RecordType;
+import io.accio.base.type.TimestampType;
+import io.accio.base.type.VarcharType;
+import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.ArrayConstructor;
+import io.trino.sql.tree.BetweenPredicate;
+import io.trino.sql.tree.BinaryLiteral;
+import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.CharLiteral;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.CurrentCatalog;
+import io.trino.sql.tree.CurrentPath;
+import io.trino.sql.tree.CurrentSchema;
+import io.trino.sql.tree.CurrentTime;
+import io.trino.sql.tree.CurrentUser;
+import io.trino.sql.tree.DateTimeDataType;
+import io.trino.sql.tree.DecimalLiteral;
+import io.trino.sql.tree.DefaultTraversalVisitor;
+import io.trino.sql.tree.DereferenceExpression;
+import io.trino.sql.tree.DoubleLiteral;
+import io.trino.sql.tree.ExistsPredicate;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.GenericDataType;
+import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.InPredicate;
+import io.trino.sql.tree.IntervalDayTimeDataType;
+import io.trino.sql.tree.IntervalLiteral;
+import io.trino.sql.tree.IsNotNullPredicate;
+import io.trino.sql.tree.IsNullPredicate;
+import io.trino.sql.tree.LikePredicate;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.NullLiteral;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.QuantifiedComparisonExpression;
+import io.trino.sql.tree.Row;
+import io.trino.sql.tree.RowDataType;
+import io.trino.sql.tree.StringLiteral;
+import io.trino.sql.tree.SubscriptExpression;
+import io.trino.sql.tree.TimeLiteral;
+import io.trino.sql.tree.TimestampLiteral;
+
+import java.util.Optional;
+
+import static io.trino.sql.tree.DereferenceExpression.getQualifiedName;
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionTypeAnalyzer
+        extends DefaultTraversalVisitor<Void>
+{
+    public static PGType<?> analyze(AccioMDL mdl, Scope scope, Expression expression)
+    {
+        ExpressionTypeAnalyzer analyzer = new ExpressionTypeAnalyzer(mdl, scope);
+        analyzer.process(expression);
+        return analyzer.result;
+    }
+
+    private final AccioMDL mdl;
+    private final Scope scope;
+    private PGType<?> result;
+
+    public ExpressionTypeAnalyzer(AccioMDL mdl, Scope scope)
+    {
+        this.mdl = requireNonNull(mdl, "mdl is null");
+        this.scope = requireNonNull(scope, "scope is null");
+    }
+
+    @Override
+    protected Void visitStringLiteral(StringLiteral node, Void context)
+    {
+        result = VarcharType.VARCHAR;
+        return null;
+    }
+
+    @Override
+    protected Void visitDoubleLiteral(DoubleLiteral node, Void context)
+    {
+        result = DoubleType.DOUBLE;
+        return null;
+    }
+
+    @Override
+    protected Void visitDecimalLiteral(DecimalLiteral node, Void context)
+    {
+        result = NumericType.NUMERIC;
+        return null;
+    }
+
+    @Override
+    protected Void visitGenericLiteral(GenericLiteral node, Void context)
+    {
+        PGTypes.nameToPgType(node.getType())
+                .ifPresent(pgType -> result = pgType);
+        return null;
+    }
+
+    @Override
+    protected Void visitTimeLiteral(TimeLiteral node, Void context)
+    {
+        // TODO: we don't support time type yet, so we treat it as timestamp type.
+        result = TimestampType.TIMESTAMP;
+        return null;
+    }
+
+    @Override
+    protected Void visitTimestampLiteral(TimestampLiteral node, Void context)
+    {
+        // TODO: timestamp literal may contain timezone, we need to handle it.
+        result = TimestampType.TIMESTAMP;
+        return null;
+    }
+
+    @Override
+    protected Void visitIntervalLiteral(IntervalLiteral node, Void context)
+    {
+        result = IntervalType.INTERVAL;
+        return null;
+    }
+
+    @Override
+    protected Void visitCharLiteral(CharLiteral node, Void context)
+    {
+        result = VarcharType.VARCHAR;
+        return null;
+    }
+
+    @Override
+    protected Void visitBinaryLiteral(BinaryLiteral node, Void context)
+    {
+        result = ByteaType.BYTEA;
+        return null;
+    }
+
+    @Override
+    protected Void visitBooleanLiteral(BooleanLiteral node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitLongLiteral(LongLiteral node, Void context)
+    {
+        result = BigIntType.BIGINT;
+        return null;
+    }
+
+    @Override
+    protected Void visitNullLiteral(NullLiteral node, Void context)
+    {
+        return super.visitNullLiteral(node, context);
+    }
+
+    @Override
+    protected Void visitCast(Cast node, Void context)
+    {
+        process(node.getType());
+        // The type is the final output. We don't need to dig into the expression.
+        return null;
+    }
+
+    @Override
+    protected Void visitRowDataType(RowDataType node, Void context)
+    {
+        result = RecordType.EMPTY_RECORD;
+        return null;
+    }
+
+    @Override
+    protected Void visitDateTimeType(DateTimeDataType node, Void context)
+    {
+        // TODO: it may contain timezone, we need to handle it.
+        result = TimestampType.TIMESTAMP;
+        return null;
+    }
+
+    @Override
+    protected Void visitIntervalDataType(IntervalDayTimeDataType node, Void context)
+    {
+        result = IntervalType.INTERVAL;
+        return null;
+    }
+
+    @Override
+    protected Void visitGenericDataType(GenericDataType node, Void context)
+    {
+        PGTypes.nameToPgType(node.getName().getValue()).ifPresent(pgType -> result = pgType);
+        return null;
+    }
+
+    @Override
+    protected Void visitInPredicate(InPredicate node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitLikePredicate(LikePredicate node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitBetweenPredicate(BetweenPredicate node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitIsNotNullPredicate(IsNotNullPredicate node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitIsNullPredicate(IsNullPredicate node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitExists(ExistsPredicate node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitComparisonExpression(ComparisonExpression node, Void context)
+    {
+        result = BooleanType.BOOLEAN;
+        return null;
+    }
+
+    @Override
+    protected Void visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Void context)
+    {
+        // TODO: we don't support quantified comparison yet.
+        return null;
+    }
+
+    @Override
+    protected Void visitFunctionCall(FunctionCall node, Void context)
+    {
+        // TODO: build a function list
+        if (node.getName().getSuffix().equalsIgnoreCase("date_trunc")) {
+            result = DateType.DATE;
+        }
+        // TODO: handle the remote name
+        else if (node.getName().getSuffix().equalsIgnoreCase("now") ||
+                node.getName().getSuffix().equalsIgnoreCase("now___timestamp")) {
+            result = TimestampType.TIMESTAMP;
+        }
+        return null;
+    }
+
+    @Override
+    protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
+    {
+        QualifiedName qualifiedName = getQualifiedName(node);
+        if (qualifiedName != null) {
+            Optional<Field> fieldOptional = scope.getRelationType().getFields().stream()
+                    .filter(field -> field.canResolve(qualifiedName))
+                    .findFirst();
+
+            fieldOptional.ifPresent(field -> result = getColumnType(field));
+        }
+        return null;
+    }
+
+    @Override
+    protected Void visitIdentifier(Identifier node, Void context)
+    {
+        QualifiedName qualifiedName = QualifiedName.of(ImmutableList.of(node));
+        scope.getRelationType().getFields().stream()
+                .filter(field -> field.canResolve(qualifiedName))
+                .findFirst()
+                .ifPresent(field -> result = getColumnType(field));
+        return null;
+    }
+
+    private PGType<?> getColumnType(Field field)
+    {
+        String objectName = field.getTableName().getSchemaTableName().getTableName();
+        String columnName = field.getColumnName();
+
+        if (mdl.getModel(objectName).isPresent()) {
+            return mdl.getModel(objectName).get().getColumns().stream()
+                    .filter(column -> columnName.equals(column.getName()))
+                    .findFirst()
+                    .flatMap(column -> PGTypes.nameToPgType(column.getType()))
+                    .orElse(null);
+        }
+        if (mdl.getMetric(objectName).isPresent()) {
+            return mdl.getMetric(objectName).get().getColumns().stream()
+                    .filter(column -> columnName.equals(column.getName()))
+                    .findFirst()
+                    .flatMap(column -> PGTypes.nameToPgType(column.getType()))
+                    .orElse(null);
+        }
+        if (mdl.getCumulativeMetric(objectName).isPresent()) {
+            CumulativeMetric cumulativeMetric = mdl.getCumulativeMetric(objectName).get();
+            if (cumulativeMetric.getMeasure().getName().equals(columnName)) {
+                return PGTypes.nameToPgType(cumulativeMetric.getMeasure().getType()).orElse(null);
+            }
+            if (cumulativeMetric.getWindow().getName().equals(columnName)) {
+                return TimestampType.TIMESTAMP;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected Void visitRow(Row node, Void context)
+    {
+        result = RecordType.EMPTY_RECORD;
+        return null;
+    }
+
+    @Override
+    protected Void visitSubscriptExpression(SubscriptExpression node, Void context)
+    {
+        process(node.getBase(), context);
+        if (result != null) {
+            result = PGTypes.getArrayType(result.oid());
+        }
+        return null;
+    }
+
+    @Override
+    protected Void visitArithmeticBinary(ArithmeticBinaryExpression node, Void context)
+    {
+        // TODO: check the type coercion rule. For now, we just use the left type.
+        process(node.getLeft());
+        return null;
+    }
+
+    @Override
+    protected Void visitCurrentTime(CurrentTime node, Void context)
+    {
+        if (node.getFunction().equals(CurrentTime.Function.DATE)) {
+            result = DateType.DATE;
+        }
+        else {
+            result = TimestampType.TIMESTAMP;
+        }
+        return null;
+    }
+
+    @Override
+    protected Void visitCurrentUser(CurrentUser node, Void context)
+    {
+        result = VarcharType.VARCHAR;
+        return null;
+    }
+
+    @Override
+    protected Void visitCurrentSchema(CurrentSchema node, Void context)
+    {
+        result = VarcharType.VARCHAR;
+        return null;
+    }
+
+    @Override
+    protected Void visitCurrentCatalog(CurrentCatalog node, Void context)
+    {
+        result = VarcharType.VARCHAR;
+        return null;
+    }
+
+    @Override
+    protected Void visitCurrentPath(CurrentPath node, Void context)
+    {
+        result = VarcharType.VARCHAR;
+        return null;
+    }
+
+    @Override
+    protected Void visitArrayConstructor(ArrayConstructor node, Void context)
+    {
+        // ALl value should be same type in array, we only check first value type here.
+        process(node.getValues().get(0));
+        if (result != null) {
+            result = PGTypes.getArrayType(result.oid());
+        }
+        return null;
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Scope.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Scope.java
@@ -27,14 +27,14 @@ public class Scope
 {
     private final Optional<Scope> parent;
     private final RelationType relationType;
-    private final boolean isTableScope;
+    private final boolean isDataSourceScope;
     private final Map<String, WithQuery> namedQueries;
 
-    private Scope(Scope parent, RelationType relationType, boolean isTableScope, Map<String, WithQuery> namedQueries)
+    private Scope(Scope parent, RelationType relationType, boolean isDataSourceScope, Map<String, WithQuery> namedQueries)
     {
         this.parent = Optional.ofNullable(parent);
         this.relationType = requireNonNull(relationType, "relationType is null");
-        this.isTableScope = isTableScope;
+        this.isDataSourceScope = isDataSourceScope;
         this.namedQueries = requireNonNull(namedQueries, "namedQueries is null");
     }
 
@@ -48,9 +48,9 @@ public class Scope
         return relationType;
     }
 
-    public boolean isTableScope()
+    public boolean isDataSourceScope()
     {
-        return isTableScope;
+        return isDataSourceScope;
     }
 
     public Optional<WithQuery> getNamedQuery(String name)
@@ -75,7 +75,7 @@ public class Scope
     {
         private Optional<Scope> parent = Optional.empty();
         private RelationType relationType = new RelationType();
-        private boolean isTableScope;
+        private boolean isDataSourceScope;
         private final Map<String, WithQuery> namedQueries = new HashMap<>();
 
         public Builder relationType(RelationType relationType)
@@ -91,9 +91,9 @@ public class Scope
             return this;
         }
 
-        public Builder isTableScope(boolean isTableScope)
+        public Builder isDataSourceScope(boolean isDataSourceScope)
         {
-            this.isTableScope = isTableScope;
+            this.isDataSourceScope = isDataSourceScope;
             return this;
         }
 
@@ -111,7 +111,7 @@ public class Scope
 
         public Scope build()
         {
-            return new Scope(parent.orElse(null), relationType, isTableScope, namedQueries);
+            return new Scope(parent.orElse(null), relationType, isDataSourceScope, namedQueries);
         }
     }
 }

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -47,6 +47,8 @@ import io.trino.sql.tree.Values;
 import io.trino.sql.tree.With;
 import io.trino.sql.tree.WithQuery;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,8 +74,14 @@ public final class StatementAnalyzer
 
     public static Analysis analyze(Statement statement, SessionContext sessionContext, AccioMDL accioMDL)
     {
+        return analyze(statement, sessionContext, accioMDL, null);
+    }
+
+    public static Analysis analyze(Statement statement, SessionContext sessionContext, AccioMDL accioMDL, TypeCoercion typeCoercion)
+    {
         Analysis analysis = new Analysis(statement);
-        new Visitor(sessionContext, analysis, accioMDL).process(statement, Optional.empty());
+        Scope queryScope = new Visitor(sessionContext, analysis, accioMDL, typeCoercion).process(statement, Optional.empty());
+        analysis.setQueryScope(queryScope);
 
         // add models directly used in sql query
         analysis.addModels(
@@ -122,12 +130,18 @@ public final class StatementAnalyzer
         private final SessionContext sessionContext;
         private final Analysis analysis;
         private final AccioMDL accioMDL;
+        private final Optional<TypeCoercion> typeCoercionOptional;
 
-        public Visitor(SessionContext sessionContext, Analysis analysis, AccioMDL accioMDL)
+        public Visitor(
+                SessionContext sessionContext,
+                Analysis analysis,
+                AccioMDL accioMDL,
+                @Nullable TypeCoercion typeCoercion)
         {
             this.sessionContext = requireNonNull(sessionContext, "sessionContext is null");
             this.analysis = requireNonNull(analysis, "analysis is null");
             this.accioMDL = requireNonNull(accioMDL, "accioMDL is null");
+            this.typeCoercionOptional = Optional.ofNullable(typeCoercion);
         }
 
         public Scope process(Node node)
@@ -150,10 +164,9 @@ public final class StatementAnalyzer
                 if (withQuery.isPresent()) {
                     // currently we only care about the table that is actually a model instead of a alias table that use cte table
                     // return empty scope here.
-                    return Scope.builder()
-                            .parent(scope)
-                            .relationType(new RelationType(List.of()))
-                            .build();
+                    Analysis analyzed = analyze(withQuery.get().getQuery(), sessionContext, accioMDL, typeCoercionOptional.orElse(null));
+                    return analyzed.getQueryScope().map(value -> createAndAssignScope(scope, value))
+                            .orElse(Scope.builder().parent(scope).build());
                 }
             }
 
@@ -161,44 +174,14 @@ public final class StatementAnalyzer
             analysis.addTable(tableName);
             if (tableName.getCatalogName().equals(accioMDL.getCatalog()) && tableName.getSchemaTableName().getSchemaName().equals(accioMDL.getSchema())) {
                 analysis.addModelNodeRef(NodeRef.of(node));
-                List<Field> fields = ImmutableList.of();
-                if (accioMDL.getModel(tableName.getSchemaTableName().getTableName()).isPresent()) {
-                    fields = accioMDL.getModel(tableName.getSchemaTableName().getTableName())
-                            .map(Model::getColumns)
-                            .orElseGet(ImmutableList::of)
-                            .stream()
-                            .map(column -> Field.builder()
-                                    .modelName(tableName)
-                                    .columnName(column.getName())
-                                    .name(column.getName())
-                                    .build())
-                            .collect(toImmutableList());
-                }
-                else if (accioMDL.getMetric(tableName.getSchemaTableName().getTableName()).isPresent()) {
-                    fields = accioMDL.getMetric(tableName.getSchemaTableName().getTableName())
-                            .map(Metric::getColumns)
-                            .orElseGet(ImmutableList::of)
-                            .stream()
-                            .map(column -> Field.builder()
-                                    .modelName(tableName)
-                                    .columnName(column.getName())
-                                    .name(column.getName())
-                                    .build())
-                            .collect(toImmutableList());
-                }
-                else if (accioMDL.getCumulativeMetric(tableName.getSchemaTableName().getTableName()).isPresent()) {
-                    CumulativeMetric cumulativeMetric = accioMDL.getCumulativeMetric(tableName.getSchemaTableName().getTableName()).get();
-                    fields = ImmutableList.of(
-                            Field.builder()
-                                    .modelName(tableName)
-                                    .columnName(cumulativeMetric.getWindow().getName())
-                                    .name(cumulativeMetric.getWindow().getName())
-                                    .build(),
-                            Field.builder()
-                                    .modelName(tableName)
-                                    .columnName(cumulativeMetric.getMeasure().getName())
-                                    .name(cumulativeMetric.getMeasure().getName())
-                                    .build());
+                List<Field> fields = collectFieldFromMDL(tableName);
+
+                // if catalog and schema matches, but table name doesn't match any model, we assume it's a remote data source table
+                if (fields.isEmpty()) {
+                    return Scope.builder()
+                            .parent(scope)
+                            .isDataSourceScope(true)
+                            .build();
                 }
                 return Scope.builder()
                         .parent(scope)
@@ -211,12 +194,55 @@ public final class StatementAnalyzer
                     .build();
         }
 
+        private List<Field> collectFieldFromMDL(CatalogSchemaTableName tableName)
+        {
+            if (accioMDL.getModel(tableName.getSchemaTableName().getTableName()).isPresent()) {
+                return accioMDL.getModel(tableName.getSchemaTableName().getTableName())
+                        .map(Model::getColumns)
+                        .orElseGet(ImmutableList::of)
+                        .stream()
+                        .map(column -> Field.builder()
+                                .modelName(tableName)
+                                .columnName(column.getName())
+                                .name(column.getName())
+                                .build())
+                        .collect(toImmutableList());
+            }
+            else if (accioMDL.getMetric(tableName.getSchemaTableName().getTableName()).isPresent()) {
+                return accioMDL.getMetric(tableName.getSchemaTableName().getTableName())
+                        .map(Metric::getColumns)
+                        .orElseGet(ImmutableList::of)
+                        .stream()
+                        .map(column -> Field.builder()
+                                .modelName(tableName)
+                                .columnName(column.getName())
+                                .name(column.getName())
+                                .build())
+                        .collect(toImmutableList());
+            }
+            else if (accioMDL.getCumulativeMetric(tableName.getSchemaTableName().getTableName()).isPresent()) {
+                CumulativeMetric cumulativeMetric = accioMDL.getCumulativeMetric(tableName.getSchemaTableName().getTableName()).get();
+                return ImmutableList.of(
+                        Field.builder()
+                                .modelName(tableName)
+                                .columnName(cumulativeMetric.getWindow().getName())
+                                .name(cumulativeMetric.getWindow().getName())
+                                .build(),
+                        Field.builder()
+                                .modelName(tableName)
+                                .columnName(cumulativeMetric.getMeasure().getName())
+                                .name(cumulativeMetric.getMeasure().getName())
+                                .build());
+            }
+            return ImmutableList.of();
+        }
+
         @Override
         protected Scope visitQuery(Query node, Optional<Scope> scope)
         {
             Optional<Scope> withScope = analyzeWith(node, scope);
             Scope queryBodyScope = process(node.getQueryBody(), withScope);
-            return createAndAssignScope(scope, queryBodyScope.getRelationType());
+            return createAndAssignScope(scope, queryBodyScope);
         }
 
         @Override
@@ -226,7 +252,7 @@ public final class StatementAnalyzer
             analyzeSelect(node, sourceScope);
             node.getWhere().ifPresent(where -> analyzeWhere(where, sourceScope));
             node.getHaving().ifPresent(having -> ExpressionAnalyzer.analyze(sourceScope, having));
-            return createAndAssignScope(scope, sourceScope.getRelationType());
+            return createAndAssignScope(scope, sourceScope);
         }
 
         private void analyzeSelect(QuerySpecification node, Scope scope)
@@ -261,6 +287,11 @@ public final class StatementAnalyzer
                 ExpressionAnalysis expressionAnalysis = ExpressionAnalyzer.analyze(scope, singleColumn.getExpression());
                 analysis.addCollectedColumns(expressionAnalysis.getCollectedFields());
             });
+
+            typeCoercionOptional.ifPresent(typeCoercion -> {
+                Optional<Expression> coerced = typeCoercion.coerceExpression(singleColumn.getExpression(), scope);
+                coerced.ifPresent(expression -> analysis.addTypeCoercion(NodeRef.of(singleColumn.getExpression()), expression));
+            });
         }
 
         private Scope analyzeFrom(QuerySpecification node, Optional<Scope> scope)
@@ -287,6 +318,8 @@ public final class StatementAnalyzer
                                                 comparisonExpression.getOperator(),
                                                 comparisonExpression.getRight())));
                     });
+            typeCoercionOptional.flatMap(typeCoercion -> typeCoercion.coerceExpression(node, scope))
+                    .ifPresent(expression -> analysis.addTypeCoercion(NodeRef.of(node), expression));
         }
 
         @Override
@@ -350,6 +383,16 @@ public final class StatementAnalyzer
             if (criteria instanceof JoinOn) {
                 Expression expression = ((JoinOn) criteria).getExpression();
                 analysis.addCollectedColumns(ExpressionAnalyzer.analyze(outputScope, expression).getCollectedFields());
+                typeCoercionOptional.ifPresent(typeCoercion -> {
+                    Optional<Expression> coerced = typeCoercion.coerceExpression(expression, outputScope);
+                    if (coerced.isPresent()) {
+                        JoinOn newJoinOn = new JoinOn(coerced.get());
+                        Join newJoin = node.getLocation().isPresent() ?
+                                new Join(node.getLocation().get(), node.getType(), node.getLeft(), node.getRight(), Optional.of(newJoinOn)) :
+                                new Join(node.getType(), node.getLeft(), node.getRight(), Optional.of(newJoinOn));
+                        analysis.addTypeCoercion(NodeRef.of(node), newJoin);
+                    }
+                });
             }
             // TODO: output scope here isn't right
             return createAndAssignScope(scope, relationType);
@@ -360,7 +403,14 @@ public final class StatementAnalyzer
         {
             Scope relationScope = process(relation.getRelation(), scope);
 
-            List<Field> fieldsWithRelationAlias = relationScope.getRelationType().getFields().stream()
+            List<Field> fields = relationScope.getRelationType().getFields();
+            // if scope is a data source scope, we should get the fields from MDL
+            if (relationScope.isDataSourceScope()) {
+                CatalogSchemaTableName tableName = toCatalogSchemaTableName(sessionContext, QualifiedName.of(relation.getAlias().getValue()));
+                fields = collectFieldFromMDL(tableName);
+            }
+
+            List<Field> fieldsWithRelationAlias = fields.stream()
                     .map(field -> Field.builder()
                             .like(field)
                             .relationAlias(QualifiedName.of(relation.getAlias().getValue()))
@@ -376,9 +426,9 @@ public final class StatementAnalyzer
         @Override
         protected Scope visitTableSubquery(TableSubquery node, Optional<Scope> scope)
         {
-            process(node.getQuery());
-            // TODO: output scope here isn't right
-            return Scope.builder().parent(scope).build();
+            Optional<Scope> analyzed = StatementAnalyzer.analyze(node.getQuery(), sessionContext, accioMDL, typeCoercionOptional.orElse(null)).getQueryScope();
+            return analyzed.map(value -> createAndAssignScope(scope, value))
+                    .orElseGet(() -> Scope.builder().parent(scope).build());
         }
 
         // TODO: will recursive query mess up anything here?
@@ -413,6 +463,15 @@ public final class StatementAnalyzer
             return Scope.builder()
                     .parent(parentScope)
                     .relationType(relationType)
+                    .build();
+        }
+
+        private Scope createAndAssignScope(Optional<Scope> parentScope, Scope scope)
+        {
+            return Scope.builder()
+                    .parent(parentScope)
+                    .isDataSourceScope(scope.isDataSourceScope())
+                    .relationType(scope.getRelationType())
                     .build();
         }
     }

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/TypeCoercion.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/TypeCoercion.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite.analyzer;
+
+import io.trino.sql.tree.Expression;
+
+import java.util.Optional;
+
+public interface TypeCoercion
+{
+    Optional<Expression> coerceExpression(Expression expression, Scope scope);
+}

--- a/accio-base/src/main/java/io/accio/base/type/PGTypes.java
+++ b/accio-base/src/main/java/io/accio/base/type/PGTypes.java
@@ -18,13 +18,16 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.accio.base.type.BigIntType.BIGINT;
 import static io.accio.base.type.BooleanType.BOOLEAN;
 import static io.accio.base.type.CharType.CHAR;
 import static io.accio.base.type.DateType.DATE;
+import static io.accio.base.type.DoubleType.DOUBLE;
 import static io.accio.base.type.HstoreType.HSTORE;
 import static io.accio.base.type.IntegerType.INTEGER;
 import static io.accio.base.type.IntervalType.INTERVAL;
@@ -44,13 +47,15 @@ public final class PGTypes
     private static final Map<Integer, PGArray> INNER_TYPE_TO_ARRAY_TABLE;
     private static final Set<PGType<?>> TYPES;
 
+    private static final Map<String, PGType<?>> TYPE_NAME_TABLE = new HashMap<>();
+
     static {
         TYPE_TABLE.put(BOOLEAN.oid(), BOOLEAN);
         TYPE_TABLE.put(SMALLINT.oid(), SMALLINT);
         TYPE_TABLE.put(INTEGER.oid(), INTEGER);
         TYPE_TABLE.put(BIGINT.oid(), BIGINT);
         TYPE_TABLE.put(REAL.oid(), REAL);
-        TYPE_TABLE.put(DoubleType.DOUBLE.oid(), DoubleType.DOUBLE);
+        TYPE_TABLE.put(DOUBLE.oid(), DOUBLE);
         TYPE_TABLE.put(NumericType.NUMERIC.oid(), NumericType.NUMERIC);
         TYPE_TABLE.put(VARCHAR.oid(), VARCHAR);
         TYPE_TABLE.put(CHAR.oid(), CHAR);
@@ -86,6 +91,14 @@ public final class PGTypes
         // the following polymorphic types are added manually,
         // because there are no corresponding data types in Cannerflow
         TYPES.add(AnyType.ANY);
+
+        TYPES.forEach(type -> TYPE_NAME_TABLE.put(type.typName().toUpperCase(Locale.ROOT), type));
+        TYPE_NAME_TABLE.put("REAL", REAL);
+        TYPE_NAME_TABLE.put("DOUBLE", DOUBLE);
+        TYPE_NAME_TABLE.put("BOOLEAN", BOOLEAN);
+        TYPE_NAME_TABLE.put("INTEGER", INTEGER);
+        TYPE_NAME_TABLE.put("SMALLINT", SMALLINT);
+        TYPE_NAME_TABLE.put("BIGINT", BIGINT);
     }
 
     public static Iterable<PGType<?>> pgTypes()
@@ -111,6 +124,11 @@ public final class PGTypes
                     format("No array type mapping from '%s' to pg_type", innerOid));
         }
         return arrayType;
+    }
+
+    public static Optional<PGType<?>> nameToPgType(String name)
+    {
+        return Optional.ofNullable(TYPE_NAME_TABLE.get(name.toUpperCase(Locale.ROOT)));
     }
 
     public static PGType<?> toPgRecordArray(PGType<?> innerRecordType)

--- a/accio-base/src/main/java/io/accio/base/type/TimestampType.java
+++ b/accio-base/src/main/java/io/accio/base/type/TimestampType.java
@@ -32,7 +32,7 @@ import static java.util.Locale.ENGLISH;
 public class TimestampType
         extends BaseTimestampType
 {
-    public static final PGType TIMESTAMP = new TimestampType();
+    public static final PGType<?> TIMESTAMP = new TimestampType();
 
     private static final int OID = 1114;
     private static final String NAME = "timestamp";

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestExpressionTypeAnalyzer.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestExpressionTypeAnalyzer.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite.analyzer;
+
+import io.accio.base.AccioMDL;
+import io.accio.base.CatalogSchemaTableName;
+import io.accio.base.dto.Model;
+import io.accio.base.sqlrewrite.AbstractTestFramework;
+import io.accio.base.type.BigIntType;
+import io.accio.base.type.BooleanType;
+import io.accio.base.type.ByteaType;
+import io.accio.base.type.DateType;
+import io.accio.base.type.DoubleType;
+import io.accio.base.type.IntegerType;
+import io.accio.base.type.IntervalType;
+import io.accio.base.type.NumericType;
+import io.accio.base.type.PGArray;
+import io.accio.base.type.RealType;
+import io.accio.base.type.RecordType;
+import io.accio.base.type.TimestampType;
+import io.accio.base.type.VarcharType;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.accio.base.AccioTypes.INTEGER;
+import static io.accio.base.AccioTypes.VARCHAR;
+import static io.accio.base.dto.Column.column;
+import static io.accio.base.dto.Model.model;
+import static io.accio.base.sqlrewrite.Utils.parseExpression;
+import static io.accio.base.sqlrewrite.analyzer.ExpressionTypeAnalyzer.analyze;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestExpressionTypeAnalyzer
+        extends AbstractTestFramework
+{
+    private static final Scope EMPTY_SCOPE = Scope.builder().build();
+    private static final AccioMDL EMPTY_MDL = AccioMDL.fromManifest(withDefaultCatalogSchema().build());
+
+    private final Model customer;
+
+    public TestExpressionTypeAnalyzer()
+    {
+        customer = model("Customer",
+                "select * from main.customer",
+                List.of(
+                        column("custkey", INTEGER, null, true),
+                        column("name", VARCHAR, null, true),
+                        column("address", VARCHAR, null, true),
+                        column("nationkey", INTEGER, null, true),
+                        column("phone", VARCHAR, null, true),
+                        column("acctbal", INTEGER, null, true),
+                        column("mktsegment", VARCHAR, null, true),
+                        column("comment", VARCHAR, null, true)),
+                "custkey");
+    }
+
+    @Test
+    public void testLiteral()
+    {
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("1"))).isEqualTo(BigIntType.BIGINT);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("'abc'"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("INTERVAL '1 month'"))).isEqualTo(IntervalType.INTERVAL);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("NULL"))).isEqualTo(null);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("TIMESTAMP '2023-10-29 00:00:00.000000'"))).isEqualTo(TimestampType.TIMESTAMP);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("REAL '3.5'"))).isEqualTo(RealType.REAL);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("x'65683F'"))).isEqualTo(ByteaType.BYTEA);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("1.1"))).isEqualTo(NumericType.NUMERIC);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("10.3e0"))).isEqualTo(DoubleType.DOUBLE);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("false"))).isEqualTo(BooleanType.BOOLEAN);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("cast(1.1 as DOUBLE)"))).isEqualTo(DoubleType.DOUBLE);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("ROW(1, 2e0)"))).isEqualTo(RecordType.EMPTY_RECORD);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("array[1,2,3]"))).isEqualTo(PGArray.INT8_ARRAY);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("array['a','b','c']"))).isEqualTo(PGArray.VARCHAR_ARRAY);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_user"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_schema"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_catalog"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_path"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_date"))).isEqualTo(DateType.DATE);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_time"))).isEqualTo(TimestampType.TIMESTAMP);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("current_timestamp"))).isEqualTo(TimestampType.TIMESTAMP);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("localtime"))).isEqualTo(TimestampType.TIMESTAMP);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("localtimestamp"))).isEqualTo(TimestampType.TIMESTAMP);
+    }
+
+    @Test
+    public void testPredicate()
+    {
+        assertPredicate("x > 1");
+        assertPredicate("x >= 1");
+        assertPredicate("x < 1");
+        assertPredicate("x <= 1");
+        assertPredicate("x = 1");
+        assertPredicate("x <> y");
+        assertPredicate("x != INTERVAL '1 month'");
+        assertPredicate("x IS NULL");
+        assertPredicate("x IS NOT NULL");
+        assertPredicate("x in (1, 2, 3)");
+        assertPredicate("x like 'abc'");
+        assertPredicate("x between 1 and 2");
+        assertPredicate("x > 1 and y < 2");
+        assertPredicate("x > 1 or y < 2");
+        assertPredicate("not x > 1");
+        assertPredicate("exists (select 1)");
+    }
+
+    private void assertPredicate(String expression)
+    {
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression(expression))).isEqualTo(BooleanType.BOOLEAN);
+    }
+
+    @Test
+    public void testFunction()
+    {
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("date_trunc('day', create_date)"))).isEqualTo(DateType.DATE);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("now()"))).isEqualTo(TimestampType.TIMESTAMP);
+        assertThat(analyze(EMPTY_MDL, EMPTY_SCOPE, parseExpression("now___timestamp()"))).isEqualTo(TimestampType.TIMESTAMP);
+    }
+
+    @Test
+    public void testColumns()
+    {
+        AccioMDL mdl = AccioMDL.fromManifest(withDefaultCatalogSchema().setModels(List.of(customer)).build());
+        List<Field> fields = customer.getColumns().stream()
+                .map(column -> Field.builder()
+                        .modelName(new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), customer.getName()))
+                        .columnName(column.getName())
+                        .name(column.getName())
+                        .build())
+                .collect(toImmutableList());
+        Scope scope = Scope.builder().relationType(new RelationType(fields)).build();
+
+        assertThat(analyze(mdl, scope, parseExpression("custkey"))).isEqualTo(IntegerType.INTEGER);
+        assertThat(analyze(mdl, scope, parseExpression("name"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("address"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("nationkey"))).isEqualTo(IntegerType.INTEGER);
+        assertThat(analyze(mdl, scope, parseExpression("phone"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("acctbal"))).isEqualTo(IntegerType.INTEGER);
+        assertThat(analyze(mdl, scope, parseExpression("mktsegment"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("comment"))).isEqualTo(VarcharType.VARCHAR);
+
+        assertThat(analyze(mdl, scope, parseExpression("Customer.custkey"))).isEqualTo(IntegerType.INTEGER);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.name"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.address"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.nationkey"))).isEqualTo(IntegerType.INTEGER);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.phone"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.acctbal"))).isEqualTo(IntegerType.INTEGER);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.mktsegment"))).isEqualTo(VarcharType.VARCHAR);
+        assertThat(analyze(mdl, scope, parseExpression("Customer.comment"))).isEqualTo(VarcharType.VARCHAR);
+    }
+}

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
@@ -28,6 +28,7 @@ import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
@@ -57,16 +58,23 @@ public class TestStatementAnalyzer
     public void testValues()
     {
         SessionContext sessionContext = SessionContext.builder().build();
-        analyze(sqlParser.createStatement("VALUES(1, 'a')", new ParsingOptions(AS_DECIMAL)), sessionContext, EMPTY);
-        analyze(sqlParser.createStatement("SELECT * FROM (VALUES(1, 'a'))", new ParsingOptions(AS_DECIMAL)), sessionContext, EMPTY);
+        Statement statement = sqlParser.createStatement("VALUES(1, 'a')", new ParsingOptions(AS_DECIMAL));
+        Analysis analysis = new Analysis(statement);
+        analyze(analysis, statement, sessionContext, EMPTY);
+
+        statement = sqlParser.createStatement("SELECT * FROM (VALUES(1, 'a'))", new ParsingOptions(AS_DECIMAL));
+        analysis = new Analysis(statement);
+        analyze(analysis, statement, sessionContext, EMPTY);
     }
 
     @Test
     public void testGetTableWithoutWithTable()
     {
         SessionContext sessionContext = SessionContext.builder().setCatalog("test").setSchema("test").build();
-        Analysis analysis = analyze(
-                sqlParser.createStatement("WITH a AS (SELECT * FROM People) SELECT * FROM a", new ParsingOptions(AS_DECIMAL)),
+        Statement statement = sqlParser.createStatement("WITH a AS (SELECT * FROM People) SELECT * FROM a", new ParsingOptions(AS_DECIMAL));
+        Analysis analysis = new Analysis(statement);
+        analyze(analysis,
+                statement,
                 sessionContext,
                 EMPTY);
 
@@ -84,10 +92,16 @@ public class TestStatementAnalyzer
                         model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2"))),
                         model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2")))))
                 .build();
-        Function<String, Analysis> analyzeSql = (sql) -> analyze(
-                sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL)),
-                sessionContext,
-                fromManifest(manifest));
+        Function<String, Analysis> analyzeSql = (sql) -> {
+            Statement statement = sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL));
+            Analysis analysis = new Analysis(statement);
+            analyze(
+                    analysis,
+                    statement,
+                    sessionContext,
+                    fromManifest(manifest));
+            return analysis;
+        };
 
         Multimap<CatalogSchemaTableName, String> expected;
         expected = HashMultimap.create();
@@ -123,10 +137,16 @@ public class TestStatementAnalyzer
                         model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), column("c2", INTEGER, null, true))),
                         model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), column("c2", DATE, null, true)))))
                 .build();
-        Function<String, Analysis> analyzeSql = (sql) -> analyze(
-                sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL)),
-                sessionContext,
-                fromManifest(manifest));
+        Function<String, Analysis> analyzeSql = (sql) -> {
+            Statement statement = sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL));
+            Analysis analysis = new Analysis(statement);
+            analyze(
+                    analysis,
+                    statement,
+                    sessionContext,
+                    fromManifest(manifest));
+            return analysis;
+        };
 
         CatalogSchemaTableName t1 = new CatalogSchemaTableName("test", "test", "table_1");
         CatalogSchemaTableName t2 = new CatalogSchemaTableName("test", "test", "table_2");
@@ -151,45 +171,51 @@ public class TestStatementAnalyzer
                         model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2"))),
                         model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2")))))
                 .build();
-        Function<String, Analysis> analyzeSql = (sql) -> analyze(
-                sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL)),
-                sessionContext,
-                fromManifest(manifest));
 
-        Optional<Scope> scope = analyzeSql.apply("SELECT * FROM table_1").getQueryScope();
+        Function<String, Scope> analyzeSql = (sql) -> {
+            Statement statement = sqlParser.createStatement(sql, new ParsingOptions(AS_DECIMAL));
+            Analysis analysis = new Analysis(statement);
+            return analyze(
+                    analysis,
+                    statement,
+                    sessionContext,
+                    fromManifest(manifest));
+        };
+
+        Optional<Scope> scope = Optional.ofNullable(analyzeSql.apply("SELECT * FROM table_1"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(2);
         assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");
         assertThat(scope.get().getRelationType().getFields().get(1).getName().get()).isEqualTo("c2");
 
-        scope = analyzeSql.apply("SELECT * FROM table_2").getQueryScope();
+        scope = Optional.ofNullable(analyzeSql.apply("SELECT * FROM table_2"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(2);
         assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");
         assertThat(scope.get().getRelationType().getFields().get(1).getName().get()).isEqualTo("c2");
 
-        scope = analyzeSql.apply("SELECT * FROM test.test.foo").getQueryScope();
+        scope = Optional.ofNullable(analyzeSql.apply("SELECT * FROM test.test.foo"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(0);
         assertThat(scope.get().isDataSourceScope()).isTrue();
 
-        scope = analyzeSql.apply("SELECT * FROM test.foo").getQueryScope();
+        scope = Optional.ofNullable(analyzeSql.apply("SELECT * FROM test.foo"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(0);
         assertThat(scope.get().isDataSourceScope()).isTrue();
 
-        scope = analyzeSql.apply("SELECT * FROM foo").getQueryScope();
+        scope = Optional.ofNullable(analyzeSql.apply("SELECT * FROM foo"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(0);
         assertThat(scope.get().isDataSourceScope()).isTrue();
 
-        scope = analyzeSql.apply("SELECT * FROM (select * from test.test.foo) table_1").getQueryScope();
+        scope = Optional.ofNullable(analyzeSql.apply("SELECT * FROM (select * from test.test.foo) table_1"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(2);
         assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");
         assertThat(scope.get().getRelationType().getFields().get(1).getName().get()).isEqualTo("c2");
 
-        scope = analyzeSql.apply("WITH t1 as (SELECT * FROM (select * from test.test.foo) table_1) select * from t1").getQueryScope();
+        scope = Optional.ofNullable(analyzeSql.apply("WITH t1 as (SELECT * FROM (select * from test.test.foo) table_1) select * from t1"));
         assertThat(scope).isPresent();
         assertThat(scope.get().getRelationType().getFields()).hasSize(2);
         assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");

--- a/accio-main/src/main/java/io/accio/main/sql/bigquery/TypeCoercionRewrite.java
+++ b/accio-main/src/main/java/io/accio/main/sql/bigquery/TypeCoercionRewrite.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.sql.bigquery;
+
+import io.accio.base.AccioMDL;
+import io.accio.base.SessionContext;
+import io.accio.base.sqlrewrite.BaseTreeRewriter;
+import io.accio.base.sqlrewrite.analyzer.Analysis;
+import io.accio.base.sqlrewrite.analyzer.StatementAnalyzer;
+import io.accio.main.metadata.Metadata;
+import io.accio.main.sql.SqlRewrite;
+import io.accio.main.sql.bigquery.analyzer.BigQueryTypeCoercion;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.Node;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.Statement;
+
+import static java.util.Objects.requireNonNull;
+
+public class TypeCoercionRewrite
+        implements SqlRewrite
+{
+    private final AccioMDL mdl;
+
+    public TypeCoercionRewrite(AccioMDL mdl)
+    {
+        this.mdl = requireNonNull(mdl, "mdl is null");
+    }
+
+    @Override
+    public Node rewrite(Node node, Metadata metadata)
+    {
+        Analysis analysis = StatementAnalyzer.analyze((Statement) node, SessionContext.builder()
+                .setCatalog(mdl.getCatalog())
+                .setSchema(mdl.getSchema())
+                .build(), mdl, new BigQueryTypeCoercion(mdl));
+        return new Rewriter(analysis).process(node);
+    }
+
+    static class Rewriter
+            extends BaseTreeRewriter<Void>
+    {
+        private final Analysis analysis;
+
+        public Rewriter(Analysis analysis)
+        {
+            this.analysis = analysis;
+        }
+
+        @Override
+        protected Node visitExpression(Expression node, Void context)
+        {
+            NodeRef<Node> nodeRef = NodeRef.of(node);
+            if (analysis.getTypeCoercionMap().containsKey(nodeRef)) {
+                return analysis.getTypeCoercionMap().get(nodeRef);
+            }
+            return node;
+        }
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/sql/bigquery/TypeCoercionRewrite.java
+++ b/accio-main/src/main/java/io/accio/main/sql/bigquery/TypeCoercionRewrite.java
@@ -42,7 +42,8 @@ public class TypeCoercionRewrite
     @Override
     public Node rewrite(Node node, Metadata metadata)
     {
-        Analysis analysis = StatementAnalyzer.analyze((Statement) node, SessionContext.builder()
+        Analysis analysis = new Analysis((Statement) node);
+        StatementAnalyzer.analyze(analysis, (Statement) node, SessionContext.builder()
                 .setCatalog(mdl.getCatalog())
                 .setSchema(mdl.getSchema())
                 .build(), mdl, new BigQueryTypeCoercion(mdl));

--- a/accio-main/src/main/java/io/accio/main/sql/bigquery/analyzer/BigQueryTypeCoercion.java
+++ b/accio-main/src/main/java/io/accio/main/sql/bigquery/analyzer/BigQueryTypeCoercion.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.sql.bigquery.analyzer;
+
+import com.google.common.collect.ImmutableList;
+import io.accio.base.AccioMDL;
+import io.accio.base.sqlrewrite.analyzer.ExpressionTypeAnalyzer;
+import io.accio.base.sqlrewrite.analyzer.Scope;
+import io.accio.base.sqlrewrite.analyzer.TypeCoercion;
+import io.accio.base.type.DateType;
+import io.accio.base.type.PGType;
+import io.accio.base.type.TimestampType;
+import io.accio.base.type.TimestampWithTimeZoneType;
+import io.airlift.log.Logger;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.ExpressionRewriter;
+import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.GenericDataType;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class BigQueryTypeCoercion
+        implements TypeCoercion
+{
+    private static final Logger LOG = Logger.get(BigQueryTypeCoercion.class);
+    private final AccioMDL mdl;
+
+    public BigQueryTypeCoercion(AccioMDL mdl)
+    {
+        this.mdl = requireNonNull(mdl, "mdl is null");
+    }
+
+    @Override
+    public Optional<Expression> coerceExpression(Expression expression, Scope scope)
+    {
+        Expression rewritten = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteComparisonExpression(ComparisonExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                PGType<?> leftType = ExpressionTypeAnalyzer.analyze(mdl, scope, node.getLeft());
+                PGType<?> rightType = ExpressionTypeAnalyzer.analyze(mdl, scope, node.getRight());
+                LOG.debug("left: %s leftType: %s, right: %s rightType: %s",
+                        node.getLeft(),
+                        leftType == null ? null : leftType.typName(),
+                        node.getRight(),
+                        rightType == null ? null : rightType.typName());
+                if (shouldBeCoerced(leftType, rightType)) {
+                    if (node.getLocation().isPresent()) {
+                        return new ComparisonExpression(node.getLocation().get(), node.getOperator(), node.getLeft(), cast(node.getLocation(), node.getRight(), leftType));
+                    }
+                    return new ComparisonExpression(node.getOperator(), node.getLeft(), cast(node.getLocation(), node.getRight(), leftType));
+                }
+                return super.rewriteComparisonExpression(node, context, treeRewriter);
+            }
+        }, expression, null);
+
+        if (!rewritten.equals(expression)) {
+            return Optional.of(rewritten);
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean shouldBeCoerced(PGType<?> leftType, PGType<?> rightType)
+    {
+        if (leftType == null || rightType == null) {
+            return false;
+        }
+
+        if (leftType.equals(rightType)) {
+            return false;
+        }
+
+        if (leftType.equals(DateType.DATE) ||
+                leftType.equals(TimestampType.TIMESTAMP) ||
+                leftType.equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIMEZONE)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private Cast cast(Optional<NodeLocation> nodeLocation, Expression expression, PGType<?> type)
+    {
+        return nodeLocation.map(location -> new Cast(location, expression, new GenericDataType(Optional.empty(), new Identifier(type.typName()), ImmutableList.of())))
+                .orElseGet(() -> new Cast(expression, new GenericDataType(Optional.empty(), new Identifier(type.typName()), ImmutableList.of())));
+    }
+}

--- a/accio-main/src/main/java/io/accio/main/web/AnalysisResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/AnalysisResource.java
@@ -24,6 +24,7 @@ import io.accio.main.web.dto.PredicateDto;
 import io.accio.main.web.dto.SqlAnalysisInputDto;
 import io.accio.main.web.dto.SqlAnalysisOutputDto;
 import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Statement;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -74,8 +75,11 @@ public class AnalysisResource
                     else {
                         mdl = AccioMDL.fromManifest(inputDto.getManifest());
                     }
-                    Analysis analysis = StatementAnalyzer.analyze(
-                            parseSql(inputDto.getSql()),
+                    Statement statement = parseSql(inputDto.getSql());
+                    Analysis analysis = new Analysis(statement);
+                    StatementAnalyzer.analyze(
+                            analysis,
+                            statement,
                             SessionContext.builder().setCatalog(mdl.getCatalog()).setSchema(mdl.getSchema()).build(),
                             mdl);
                     return toSqlAnalysisOutputDto(analysis.getSimplePredicates());

--- a/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
+++ b/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
@@ -16,6 +16,7 @@ package io.accio;
 
 import io.accio.base.AccioMDL;
 import io.accio.base.SessionContext;
+import io.accio.base.dto.Manifest;
 import io.accio.connector.bigquery.BigQueryClient;
 import io.accio.main.AccioMetastore;
 import io.accio.main.connector.bigquery.BigQueryConfig;
@@ -52,7 +53,7 @@ public class TestBigQuerySqlConverter
 
         BigQueryMetadata bigQueryMetadata = new BigQueryMetadata(bigQueryClient, config);
         AccioMetastore accioMetastore = new AccioMetastore();
-        accioMetastore.setAccioMDL(AccioMDL.EMPTY);
+        accioMetastore.setAccioMDL(AccioMDL.fromManifest(Manifest.builder().setCatalog("canner-cml").setSchema("tpch_tiny").build()));
         bigQuerySqlConverter = new BigQuerySqlConverter(bigQueryMetadata, accioMetastore);
     }
 

--- a/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
+++ b/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
@@ -14,8 +14,10 @@
 
 package io.accio;
 
+import io.accio.base.AccioMDL;
 import io.accio.base.SessionContext;
 import io.accio.connector.bigquery.BigQueryClient;
+import io.accio.main.AccioMetastore;
 import io.accio.main.connector.bigquery.BigQueryConfig;
 import io.accio.main.connector.bigquery.BigQueryMetadata;
 import io.accio.main.connector.bigquery.BigQuerySqlConverter;
@@ -45,7 +47,9 @@ public class TestBigQuerySqlConverter
                 BigQueryConnectorModule.provideBigQueryCredentialsSupplier(config));
 
         BigQueryMetadata bigQueryMetadata = new BigQueryMetadata(bigQueryClient, config);
-        bigQuerySqlConverter = new BigQuerySqlConverter(bigQueryMetadata);
+        AccioMetastore accioMetastore = new AccioMetastore();
+        accioMetastore.setAccioMDL(AccioMDL.EMPTY);
+        bigQuerySqlConverter = new BigQuerySqlConverter(bigQueryMetadata, accioMetastore);
     }
 
     @Test

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
@@ -26,6 +26,7 @@ import io.airlift.log.Logger;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static io.accio.base.Utils.randomIntString;
 import static java.lang.String.format;
@@ -69,6 +70,11 @@ public abstract class AbstractWireProtocolTestWithBigQuery
         return TestingAccioServer.builder()
                 .setRequiredConfigs(properties.build())
                 .build();
+    }
+
+    protected Optional<String> getAccioMDLPath()
+    {
+        return Optional.of(requireNonNull(getClass().getClassLoader().getResource("tpch_mdl.json")).getPath());
     }
 
     @Override

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
@@ -17,7 +17,6 @@ package io.accio.testing.bigquery;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Key;
-import io.accio.base.AccioMDL;
 import io.accio.base.dto.Manifest;
 import io.accio.connector.bigquery.BigQueryClient;
 import io.accio.main.metadata.Metadata;
@@ -36,6 +35,10 @@ import static java.util.Objects.requireNonNull;
 public abstract class AbstractWireProtocolTestWithBigQuery
         extends AbstractWireProtocolTest
 {
+    private static final Manifest DEFAULT_MANIFEST = Manifest.builder()
+            .setCatalog("canner-cml")
+            .setSchema("tpch_tiny")
+            .build();
     private static final Logger LOG = Logger.get(AbstractWireProtocolTestWithBigQuery.class);
 
     @Override
@@ -55,7 +58,7 @@ public abstract class AbstractWireProtocolTestWithBigQuery
                 Files.copy(Path.of(getAccioMDLPath().get()), dir.resolve("mdl.json"));
             }
             else {
-                Files.write(dir.resolve("manifest.json"), Manifest.MANIFEST_JSON_CODEC.toJsonBytes(AccioMDL.EMPTY.getManifest()));
+                Files.write(dir.resolve("manifest.json"), Manifest.MANIFEST_JSON_CODEC.toJsonBytes(DEFAULT_MANIFEST));
             }
             properties.put("accio.directory", dir.toString());
         }

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestBigQueryCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestBigQueryCache.java
@@ -144,7 +144,8 @@ public class TestBigQueryCache
                 {"c_boolean", true},
                 {"c_timestamp", "'2020-01-01 15:10:55'"},
                 {"c_date", "'2020-01-01'"},
-                {"c_datetime", "'2020-01-01 15:10:55.123456'"},
+                // TODO: handle bq datetime type. It can't be mapped to PG type
+                // {"c_datetime", "'2020-01-01 15:10:55.123456'"},
         };
     }
 

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestFunctions.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestFunctions.java
@@ -114,7 +114,7 @@ public class TestFunctions
             throws SQLException
     {
         try (Connection conn = createConnection()) {
-            PreparedStatement stmt = conn.prepareStatement("SELECT substring(tpch_tiny.lineitem.l_comment FROM ?) FROM tpch_tiny.lineitem LIMIT 1");
+            PreparedStatement stmt = conn.prepareStatement("SELECT substring(Lineitem.comment FROM ?) FROM Lineitem LIMIT 1");
             stmt.setString(1, "[a-z]+");
             ResultSet result = stmt.executeQuery();
             assertThat(result.next()).isTrue();

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -1264,6 +1264,59 @@ public class TestWireProtocolWithBigquery
         assertThatThrownBy(() -> createConnection(props)).hasMessageContaining("user is empty");
     }
 
+    @Test
+    public void testIntervalCompareWithTimestamp()
+            throws Exception
+    {
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT shipdate FROM Lineitem WHERE shipdate > current_date + interval '1' day");
+                resultSet.next();
+            });
+        }
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT shipdate FROM Lineitem WHERE shipdate > current_timestamp + interval '1' day");
+                resultSet.next();
+            });
+        }
+
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT shipdate FROM Lineitem WHERE shipdate > current_date + interval '1 week'");
+                resultSet.next();
+            });
+        }
+
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT shipdate FROM Lineitem WHERE shipdate > current_date + interval '1' day AND shipdate > current_date + interval '1' day");
+                resultSet.next();
+            });
+        }
+
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT shipdate > current_date + interval '1' day FROM Lineitem");
+                resultSet.next();
+            });
+        }
+
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT shipdate > current_date + interval '1' day AND shipdate < now() FROM Lineitem");
+                resultSet.next();
+            });
+        }
+
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT cast(shipdate as timestamp) = date_trunc('month', shipdate) FROM Lineitem");
+                resultSet.next();
+            });
+        }
+    }
+
     protected static void assertDefaultPgConfigResponse(TestingWireProtocolClient protocolClient)
             throws IOException
     {

--- a/accio-tests/src/test/resources/tpch_mdl.json
+++ b/accio-tests/src/test/resources/tpch_mdl.json
@@ -127,6 +127,11 @@
           "type": "date"
         },
         {
+          "name": "comment",
+          "expression": "l_comment",
+          "type": "varchar"
+        },
+        {
           "name": "order",
           "type": "int4",
           "expression": "1"

--- a/trino-parser/src/main/java/io/trino/sql/util/IntervalLiteralUtil.java
+++ b/trino-parser/src/main/java/io/trino/sql/util/IntervalLiteralUtil.java
@@ -34,6 +34,9 @@ public final class IntervalLiteralUtil
         String[] strings = text.split(" ");
         String value = strings[0].replaceFirst("[-+]", "");
         IntervalLiteral.Sign sign = (strings[0].startsWith("-")) ? NEGATIVE : POSITIVE;
+        if (strings[1].equalsIgnoreCase("week")) {
+            return new IntervalLiteral(location, Long.toString(Long.parseLong(value) * 7), sign, IntervalLiteral.IntervalField.DAY, Optional.empty());
+        }
         IntervalLiteral.IntervalField field = IntervalLiteral.IntervalField.valueOf(strings[1].toUpperCase(Locale.ROOT));
 
         return new IntervalLiteral(location, value, sign, field, Optional.empty());


### PR DESCRIPTION
# Description
Refer to [BigQuery Type Conversion Rule](https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules), it's very weak to do timestamp-related type conversion. If the timestamp-related type can't be work with other time type, such as `DATE`, `TIME`, it's very inconvenience for normal SQL user.

In this PR, we supports to detect the Type Coercion request automatically. Any type coercion request, we may wrap what need to be coerced in a `CAST` expression. For now, any type coercion is based on what type left side is.

Now, user can query like as below, assume `shipdate` is a `TIMESTAMP` column in BigQuery.
```
SELECT shipdate FROM Lineitem WHERE shipdate > current_date + interval '1' day
```

# TODO Issue
- Function list for return type.
- Handle remote function name.
- Handle timestamp with tz type
- support to analyze quantified comparison type
- support bq datetime type (handle type not int pg)
- more pg type  name alias