### PR TITLE
Add CI to build image with specify branch and commit

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,9 +3,9 @@ name: Build image
 on:
   workflow_dispatch:
     inputs:
-      docker_image_name:
+      docker_image_tag_name:
         type: string
-        description: Docker image name (Optional)
+        description: Docker image tag name (Optional)
 
 jobs:
   build-image:
@@ -34,8 +34,8 @@ jobs:
       - name: Prepare tag name
         id: prepare_tag
         run: |
-          if [ -n "${{ github.event.inputs.docker_image_name }}" ]; then
-            tag_name=${{ github.event.inputs.docker_image_name }}
+          if [ -n "${{ github.event.inputs.docker_image_tag_name }}" ]; then
+            tag_name=${{ github.event.inputs.docker_image_tag_name }}
           else
             tag_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g')-$(git log -1 --pretty=%h)
           fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,17 +6,12 @@ on:
       docker_image_name:
         type: string
         description: Docker image name (default {branch name}-{commit hash})
-      specify_commit:
-        type: string
-        description: Checkout specific commit (default latest commit)
 
 jobs:
   build-image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.specify_commit || github.ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       docker_image_name:
         type: string
-        description: Docker image name (default {branch name}-{commit hash})
+        description: Docker image name (Optional)
 
 jobs:
   build-image:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,10 +5,10 @@ on:
     inputs:
       image_tag_name:
         type: string
-        description: Specify the image tag or leave it empty to use the latest commit hash as the tag
+        description: Specify the image tag name (Optional)
       specify_commit:
         type: string
-        description: Specify the commit hash to build the image
+        description: Specify the commit hash (Optional)
 
 jobs:
   build-image:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -37,19 +37,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Prepare tag name
+        id: prepare_tag
+        run: |
+          if [ -n "${{ github.event.inputs.image_tag_name }}" ]; then
+            tag_name=${{ github.event.inputs.image_tag_name }}
+          else
+            tag_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g')-$(git log -1 --pretty=%h)
+          fi
+          echo ::set-output name=tag_name::$tag_name
       - name: Build Docker image
         run: |
           ACCIO_VERSION=$(./mvnw --quiet help:evaluate -Dexpression=project.version -DforceStdout)
-          if [ -z "${{ inputs.image_tag_name }}" ]; then
-            tag_name=${{ github.ref_name | sed 's/[^a-zA-Z0-9]/-/g' }}-$(git log -1 --pretty=%h)
-          else
-            tag_name=${{ inputs.image_tag_name }}
-          fi
           cd ./docker
           cp ../accio-server/target/accio-server-${ACCIO_VERSION}-executable.jar ./
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --tag ghcr.io/canner/accio:${tag_name} \
+            --tag ghcr.io/canner/accio:${{ steps.prepare_tag.outputs.tag_name }} \
             --tag ghcr.io/canner/accio:latest \
             --push -f ./Dockerfile \
             --build-arg "ACCIO_VERSION=${ACCIO_VERSION}" .

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ specify_commit || github.ref }}
+          ref: ${{ inputs.specify_commit || github.ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,7 +23,6 @@ jobs:
           java-version: 11
           distribution: 'adopt'
           cache: 'maven'
-          cache-dependency-path: '**/pom.xml'
       - name: Build
         run: |
           ./mvnw clean install -B -DskipTests -P exec-jar

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,12 +3,12 @@ name: Build image
 on:
   workflow_dispatch:
     inputs:
-      image_tag_name:
+      docker_image_name:
         type: string
-        description: Specify the image tag name (Optional)
+        description: Docker image name (default {branch name}-{commit hash})
       specify_commit:
         type: string
-        description: Specify the commit hash (Optional)
+        description: Checkout specific commit (default latest commit)
 
 jobs:
   build-image:
@@ -39,8 +39,8 @@ jobs:
       - name: Prepare tag name
         id: prepare_tag
         run: |
-          if [ -n "${{ github.event.inputs.image_tag_name }}" ]; then
-            tag_name=${{ github.event.inputs.image_tag_name }}
+          if [ -n "${{ github.event.inputs.docker_image_name }}" ]; then
+            tag_name=${{ github.event.inputs.docker_image_name }}
           else
             tag_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g')-$(git log -1 --pretty=%h)
           fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,6 +54,5 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --tag ghcr.io/canner/accio:${{ steps.prepare_tag.outputs.tag_name }} \
-            --tag ghcr.io/canner/accio:latest \
             --push -f ./Dockerfile \
             --build-arg "ACCIO_VERSION=${ACCIO_VERSION}" .

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           ACCIO_VERSION=$(./mvnw --quiet help:evaluate -Dexpression=project.version -DforceStdout)
           if [ -z "${{ inputs.image_tag_name }}" ]; then
-            tag_name=${{ github.ref_name }}-$(git log -1 --pretty=%h)
+            tag_name=${{ github.ref_name | sed 's/[^a-zA-Z0-9]/-/g' }}-$(git log -1 --pretty=%h)
           else
             tag_name=${{ inputs.image_tag_name }}
           fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,55 @@
+name: Build image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag_name:
+        type: string
+        description: Specify the image tag or leave it empty to use the latest commit hash as the tag
+      specify_commit:
+        type: string
+        description: Specify the commit hash to build the image
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ specify_commit || github.ref }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          cache: 'maven'
+          cache-dependency-path: '**/pom.xml'
+      - name: Build
+        run: |
+          ./mvnw clean install -B -DskipTests -P exec-jar
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: |
+          ACCIO_VERSION=$(./mvnw --quiet help:evaluate -Dexpression=project.version -DforceStdout)
+          if [ -z "${{ inputs.image_tag_name }}" ]; then
+            tag_name=${{ github.ref_name }}-$(git log -1 --pretty=%h)
+          else
+            tag_name=${{ inputs.image_tag_name }}
+          fi
+          cd ./docker
+          cp ../accio-server/target/accio-server-${ACCIO_VERSION}-executable.jar ./
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/canner/accio:${tag_name} \
+            --tag ghcr.io/canner/accio:latest \
+            --push -f ./Dockerfile \
+            --build-arg "ACCIO_VERSION=${ACCIO_VERSION}" .


### PR DESCRIPTION
## Description
The new workflow can receive a specific branch to build the image. It also can receive a specific docker image tag name instead of the default name `branchName-commitSHA`.

<img width="336" alt="image" src="https://github.com/Canner/accio/assets/8724385/1803043d-6145-40fb-aac2-c6d32ed13522">
