### PR TITLE
Create dummy CTE when selecting table without any required field in dynamic mode

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioDataLineage.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioDataLineage.java
@@ -100,7 +100,8 @@ public class AccioDataLineage
      * Retrieve tables in the order of CTE generation and their respective required columns for the given column.
      *
      * @param columnNames list of QualifiedName, the qualified name should only have two elements, first element is table name, second element is column name.
-     * @return {@code LinkedHashMap<String, Set<String>>} which key is table name, value is a set of column names
+     * @return {@code LinkedHashMap<String, Set<String>>} which key is table name, value is a set of column names.
+     * The order of the entry is the order of CTE generation. That's why use LinkedHashMap.
      */
     public LinkedHashMap<String, Set<String>> getRequiredFields(List<QualifiedName> columnNames)
     {

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
@@ -118,6 +118,9 @@ public class AccioSqlRewrite
                 withQueries.add(getWithQuery(DateSpineInfo.get(accioMDL.getDateSpine())));
             }
             descriptors.forEach(queryDescriptor -> withQueries.add(getWithQuery(queryDescriptor)));
+            // If a selected table lacks any required fields, create a dummy with query for it.
+            analysis.getTables().stream().filter(table -> !tableRequiredFields.containsKey(table.getSchemaTableName().getTableName()))
+                    .forEach(dummy -> withQueries.add(getWithQuery(new DummyInfo(dummy.getSchemaTableName().getTableName()))));
 
             Node rewriteWith = new WithRewriter(withQueries).process(root);
             return (Statement) new Rewriter(accioMDL, analysis).process(rewriteWith);

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/DummyInfo.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/DummyInfo.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite;
+
+import io.trino.sql.tree.Query;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class DummyInfo
+        implements QueryDescriptor
+{
+    private final String name;
+
+    public DummyInfo(String name)
+    {
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Set<String> getRequiredObjects()
+    {
+        return Set.of();
+    }
+
+    @Override
+    public Query getQuery()
+    {
+        return Utils.parseQuery("select 1");
+    }
+}

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestCumulativeMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestCumulativeMetric.java
@@ -40,6 +40,7 @@ import static io.accio.base.dto.Model.onBaseObject;
 import static io.accio.base.dto.Window.window;
 import static io.accio.base.sqlrewrite.AccioSqlRewrite.ACCIO_SQL_REWRITE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestCumulativeMetric
@@ -102,6 +103,11 @@ public class TestCumulativeMetric
             assertThat(query(rewrite("select * from QuarterlyRevenue", accioMDL, enableDynamic)).size()).isEqualTo(8);
             assertThat(query(rewrite("select * from YearlyRevenue", accioMDL, enableDynamic)).size()).isEqualTo(5);
         });
+
+        List.of(true, false).forEach(enableDynamic -> {
+            assertThatCode(() -> query(rewrite("SELECT 1 FROM DailyRevenue", accioMDL, true)))
+                    .doesNotThrowAnyException();
+        });
     }
 
     @Test
@@ -127,6 +133,11 @@ public class TestCumulativeMetric
             assertThat(result.get(0).size()).isEqualTo(2);
             assertThat(result.size()).isEqualTo(53);
         });
+
+        List.of(true, false).forEach(enableDynamic -> {
+            assertThatCode(() -> query(rewrite("SELECT 1 FROM testModelOnCumulativeMetric", mdl, true)))
+                    .doesNotThrowAnyException();
+        });
     }
 
     @Test
@@ -151,6 +162,11 @@ public class TestCumulativeMetric
             assertThat(result.get(0).size()).isEqualTo(2);
             assertThat(result.size()).isEqualTo(12);
         });
+
+        List.of(true, false).forEach(enableDynamic -> {
+            assertThatCode(() -> query(rewrite("SELECT 1 FROM testMetricOnCumulativeMetric", mdl, true)))
+                    .doesNotThrowAnyException();
+        });
     }
 
     @Test
@@ -171,6 +187,11 @@ public class TestCumulativeMetric
             List<List<Object>> result = query(rewrite("SELECT * FROM testCumulativeMetricOnCumulativeMetric ORDER BY orderyear", mdl, enableDynamic));
             assertThat(result.get(0).size()).isEqualTo(2);
             assertThat(result.size()).isEqualTo(5);
+        });
+
+        List.of(true, false).forEach(enableDynamic -> {
+            assertThatCode(() -> query(rewrite("SELECT 1 FROM testCumulativeMetricOnCumulativeMetric", mdl, true)))
+                    .doesNotThrowAnyException();
         });
     }
 
@@ -219,6 +240,11 @@ public class TestCumulativeMetric
             List<List<Object>> result = query(rewrite("SELECT * FROM testCumulativeMetricOnMetric ORDER BY orderyear", mdl, enableDynamic));
             assertThat(result.get(0).size()).isEqualTo(2);
             assertThat(result.size()).isEqualTo(5);
+        });
+
+        List.of(true, false).forEach(enableDynamic -> {
+            assertThatCode(() -> query(rewrite("SELECT 1 FROM testCumulativeMetricOnMetric", mdl, true)))
+                    .doesNotThrowAnyException();
         });
     }
 

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
@@ -42,6 +42,7 @@ import static io.accio.base.dto.TimeUnit.MONTH;
 import static io.accio.base.dto.TimeUnit.YEAR;
 import static io.accio.base.sqlrewrite.AccioSqlRewrite.ACCIO_SQL_REWRITE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class TestMetric
@@ -253,6 +254,13 @@ public class TestMetric
     }
 
     @Test
+    public void testSelectEmptyWithDynamic()
+    {
+        assertThatCode(() -> query(rewrite("select 1 from TotalpriceByCustomerBaseOrders", true)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
     public void testModelOnMetric()
     {
         List<Model> models = ImmutableList.<Model>builder()
@@ -273,6 +281,9 @@ public class TestMetric
         List<List<Object>> result = query(rewrite("select * from testModelOnMetric", mdl));
         assertThat(result.get(0).size()).isEqualTo(2);
         assertThat(result.size()).isEqualTo(14958);
+
+        assertThatCode(() -> query(rewrite("select 1 from testModelOnMetric", true)))
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -292,6 +303,9 @@ public class TestMetric
         List<List<Object>> result = query(rewrite("SELECT * FROM testMetricOnMetric ORDER BY orderyear", mdl));
         assertThat(result.get(0).size()).isEqualTo(2);
         assertThat(result.size()).isEqualTo(7);
+
+        assertThatCode(() -> query(rewrite("select 1 from testMetricOnMetric", true)))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
# Description
Some BI tools will select a table without any required field like `Metabase` query a table using:
```sql
SELECT true "_"
FROM
  Metric_Revenue
WHERE (1 <> 1)
LIMIT 0
```

We should create a dummy CTE when required fields is empty but exist selected tables.