### PR TITLE
Modified MDL-related API

### DIFF
--- a/accio-base/src/main/java/io/accio/base/AnalyzedMDL.java
+++ b/accio-base/src/main/java/io/accio/base/AnalyzedMDL.java
@@ -16,23 +16,28 @@ package io.accio.base;
 
 import io.accio.base.sqlrewrite.AccioDataLineage;
 
+import javax.annotation.Nullable;
+
 import static java.util.Objects.requireNonNull;
 
 public class AnalyzedMDL
 {
     private final AccioMDL accioMDL;
     private final AccioDataLineage accioDataLineage;
+    private final String version;
 
-    public AnalyzedMDL(AccioMDL accioMDL)
+    public AnalyzedMDL(AccioMDL accioMDL, @Nullable String version)
     {
         this.accioMDL = requireNonNull(accioMDL);
         this.accioDataLineage = AccioDataLineage.analyze(accioMDL);
+        this.version = version;
     }
 
-    public AnalyzedMDL(AccioMDL accioMDL, AccioDataLineage accioDataLineage)
+    public AnalyzedMDL(AccioMDL accioMDL, AccioDataLineage accioDataLineage, @Nullable String version)
     {
         this.accioMDL = requireNonNull(accioMDL);
         this.accioDataLineage = requireNonNull(accioDataLineage);
+        this.version = version;
     }
 
     public AccioMDL getAccioMDL()
@@ -43,5 +48,11 @@ public class AnalyzedMDL
     public AccioDataLineage getAccioDataLineage()
     {
         return accioDataLineage;
+    }
+
+    @Nullable
+    public String getVersion()
+    {
+        return version;
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestAllRulesRewrite.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestAllRulesRewrite.java
@@ -154,6 +154,6 @@ public class TestAllRulesRewrite
 
     private String rewrite(String sql)
     {
-        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL));
+        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL, null));
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestCumulativeMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestCumulativeMetric.java
@@ -255,6 +255,6 @@ public class TestCumulativeMetric
                 .setSchema("test")
                 .setEnableDynamic(enableDynamic)
                 .build();
-        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL), List.of(ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL, null), List.of(ACCIO_SQL_REWRITE));
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestEnumRewrite.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestEnumRewrite.java
@@ -92,7 +92,7 @@ public class TestEnumRewrite
 
     private Statement rewrite(String sql)
     {
-        return ENUM_REWRITE.apply(parse(sql), DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL));
+        return ENUM_REWRITE.apply(parse(sql), DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL, null));
     }
 
     private Statement parse(String sql)

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
@@ -370,7 +370,7 @@ public class TestMetric
 
     private String rewrite(String sql, AccioMDL accioMDL)
     {
-        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL), List.of(ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL, null), List.of(ACCIO_SQL_REWRITE));
     }
 
     private String rewrite(String sql, AccioMDL accioMDL, boolean enableDynamicField)
@@ -380,6 +380,6 @@ public class TestMetric
                 .setSchema("test")
                 .setEnableDynamic(enableDynamicField)
                 .build();
-        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL), List.of(ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL, null), List.of(ACCIO_SQL_REWRITE));
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetricViewSqlRewrite.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetricViewSqlRewrite.java
@@ -313,6 +313,6 @@ public class TestMetricViewSqlRewrite
 
     private String rewrite(String sql, AccioMDL accioMDL)
     {
-        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL), List.of(METRIC_ROLLUP_REWRITE, ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL, null), List.of(METRIC_ROLLUP_REWRITE, ACCIO_SQL_REWRITE));
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModel.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModel.java
@@ -333,6 +333,6 @@ public class TestModel
                 .setSchema("test")
                 .setEnableDynamic(enableDynamicField)
                 .build();
-        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL), List.of(ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL, null), List.of(ACCIO_SQL_REWRITE));
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModelSqlRewrite.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModelSqlRewrite.java
@@ -362,7 +362,7 @@ public class TestModelSqlRewrite
 
     private static String rewrite(String sql, AccioMDL mdl)
     {
-        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(mdl), List.of(ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(mdl, null), List.of(ACCIO_SQL_REWRITE));
     }
 
     private static void assertSqlEquals(String actual, String expected)

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestView.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestView.java
@@ -99,6 +99,6 @@ public class TestView
                 .setSchema("test")
                 .setEnableDynamic(enableDynamicField)
                 .build();
-        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL), List.of(ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(accioMDL, null), List.of(ACCIO_SQL_REWRITE));
     }
 }

--- a/accio-main/src/main/java/io/accio/main/AccioMetastore.java
+++ b/accio-main/src/main/java/io/accio/main/AccioMetastore.java
@@ -24,15 +24,15 @@ import static io.accio.base.AccioMDL.EMPTY;
 
 public class AccioMetastore
 {
-    private final AtomicReference<AnalyzedMDL> analyzed = new AtomicReference<>(new AnalyzedMDL(EMPTY, AccioDataLineage.EMPTY));
+    private final AtomicReference<AnalyzedMDL> analyzed = new AtomicReference<>(new AnalyzedMDL(EMPTY, AccioDataLineage.EMPTY, "0"));
 
     public AnalyzedMDL getAnalyzedMDL()
     {
         return analyzed.get();
     }
 
-    public synchronized void setAccioMDL(AccioMDL accioMDL)
+    public synchronized void setAccioMDL(AccioMDL accioMDL, String version)
     {
-        this.analyzed.set(new AnalyzedMDL(accioMDL, AccioDataLineage.analyze(accioMDL)));
+        this.analyzed.set(new AnalyzedMDL(accioMDL, AccioDataLineage.analyze(accioMDL), version));
     }
 }

--- a/accio-main/src/main/java/io/accio/main/PreviewService.java
+++ b/accio-main/src/main/java/io/accio/main/PreviewService.java
@@ -53,7 +53,7 @@ public class PreviewService
                     .setSchema(mdl.getSchema())
                     .build();
 
-            String planned = AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(mdl));
+            String planned = AccioPlanner.rewrite(sql, sessionContext, new AnalyzedMDL(mdl, null));
             String converted = sqlConverter.convert(planned, sessionContext);
             return Streams.stream(metadata.directQuery(converted, List.of()))
                     .limit(limit)

--- a/accio-main/src/main/java/io/accio/main/web/dto/CheckOutputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/CheckOutputDto.java
@@ -16,18 +16,17 @@ package io.accio.main.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.accio.base.dto.Manifest;
 
 public class CheckOutputDto
 {
-    public static CheckOutputDto ready(Manifest manifest)
+    public static CheckOutputDto ready(String version)
     {
-        return new CheckOutputDto(Status.READY, manifest);
+        return new CheckOutputDto(Status.READY, version);
     }
 
-    public static CheckOutputDto prepare(Manifest manifest)
+    public static CheckOutputDto prepare(String version)
     {
-        return new CheckOutputDto(Status.PREPARING, manifest);
+        return new CheckOutputDto(Status.PREPARING, version);
     }
 
     public enum Status
@@ -37,15 +36,15 @@ public class CheckOutputDto
     }
 
     private final Status status;
-    private final Manifest manifest;
+    private final String version;
 
     @JsonCreator
     public CheckOutputDto(
             @JsonProperty("systemStatus") Status status,
-            @JsonProperty("manifest") Manifest manifest)
+            @JsonProperty("version") String version)
     {
         this.status = status;
-        this.manifest = manifest;
+        this.version = version;
     }
 
     @JsonProperty
@@ -55,8 +54,8 @@ public class CheckOutputDto
     }
 
     @JsonProperty
-    public Manifest getManifest()
+    public String getVersion()
     {
-        return manifest;
+        return version;
     }
 }

--- a/accio-main/src/main/java/io/accio/main/web/dto/DeployInputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/DeployInputDto.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.accio.base.dto.Manifest;
+
+public class DeployInputDto
+{
+    private final Manifest manifest;
+    private final String version;
+
+    @JsonCreator
+    public DeployInputDto(
+            @JsonProperty("manifest") Manifest manifest,
+            @JsonProperty("version") String version)
+    {
+        this.manifest = manifest;
+        this.version = version;
+    }
+
+    @JsonProperty
+    public Manifest getManifest()
+    {
+        return manifest;
+    }
+
+    @JsonProperty
+    public String getVersion()
+    {
+        return version;
+    }
+}

--- a/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
+++ b/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
@@ -53,7 +53,7 @@ public class TestBigQuerySqlConverter
 
         BigQueryMetadata bigQueryMetadata = new BigQueryMetadata(bigQueryClient, config);
         AccioMetastore accioMetastore = new AccioMetastore();
-        accioMetastore.setAccioMDL(AccioMDL.fromManifest(Manifest.builder().setCatalog("canner-cml").setSchema("tpch_tiny").build()));
+        accioMetastore.setAccioMDL(AccioMDL.fromManifest(Manifest.builder().setCatalog("canner-cml").setSchema("tpch_tiny").build()), null);
         bigQuerySqlConverter = new BigQuerySqlConverter(bigQueryMetadata, accioMetastore);
     }
 

--- a/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
@@ -103,7 +103,8 @@ public class TestMDLResource
         assertThat(getCurrentManifest().getModels().get(0).getColumns().size()).isEqualTo(1);
         waitUntilReady();
 
-        assertThat(requireNonNull(mdlDir.resolve("archive").toFile().listFiles()).length).isGreaterThanOrEqualTo(2);
+        assertThat(requireNonNull(mdlDir.resolve("archive").toFile().listFiles()).length).isEqualTo(2);
+        assertThatNoException().isThrownBy(() -> preview(new PreviewDto(null, "select orderkey from Orders limit 100", null)));
     }
 
     @Test
@@ -132,9 +133,7 @@ public class TestMDLResource
         assertThat(preview2.size()).isEqualTo(150);
         assertThat(preview2.get(0).length).isEqualTo(1);
 
-        assertThatNoException().isThrownBy(() -> deployMDL(new DeployInputDto(initial, null)));
         assertWebApplicationException(() -> preview(new PreviewDto(previewManifest, "select orderkey from Orders limit 100", null)))
                 .hasErrorMessageMatches(".*Table \"Orders\" must be qualified with a dataset.*");
-        assertThatNoException().isThrownBy(() -> preview(new PreviewDto(null, "select orderkey from Orders limit 100", null)));
     }
 }

--- a/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
@@ -103,7 +103,7 @@ public class TestMDLResource
         assertThat(getCurrentManifest().getModels().get(0).getColumns().size()).isEqualTo(1);
         waitUntilReady();
 
-        assertThat(requireNonNull(mdlDir.resolve("archive").toFile().listFiles()).length).isEqualTo(2);
+        assertThat(requireNonNull(mdlDir.resolve("archive").toFile().listFiles()).length).isGreaterThanOrEqualTo(2);
     }
 
     @Test

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestDuckdbRetryCacheTask.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestDuckdbRetryCacheTask.java
@@ -69,7 +69,7 @@ public class TestDuckdbRetryCacheTask
         Optional<Model> model = mdl.getModel("Orders");
         assertThat(model).isPresent();
 
-        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdl), model.get()).join();
+        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdl, null), model.get()).join();
         assertThat(start.getTaskStatus()).isEqualTo(QUEUED);
         assertThat(start.getEndTime()).isNull();
         cacheManager.get().untilTaskDone(ordersName);

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestDuckdbTaskManager.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestDuckdbTaskManager.java
@@ -103,7 +103,7 @@ public class TestDuckdbTaskManager
         Optional<Model> model = mdl.getModel("Orders");
         assertThat(model).isPresent();
 
-        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdl), model.get()).join();
+        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdl, null), model.get()).join();
         assertThat(start.getTaskStatus()).isEqualTo(QUEUED);
         assertThat(start.getEndTime()).isNull();
         cacheManager.get().untilTaskDone(ordersName);
@@ -126,7 +126,7 @@ public class TestDuckdbTaskManager
         Optional<Model> model = mdlWithWrongSql.getModel("WrongOrders");
         assertThat(model).isPresent();
 
-        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdlWithWrongSql), model.get()).join();
+        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdlWithWrongSql, null), model.get()).join();
         assertThat(start.getTaskStatus()).isEqualTo(QUEUED);
 
         CatalogSchemaTableName wrongOrdersName = catalogSchemaTableName(mdlWithWrongSql.getCatalog(), mdlWithWrongSql.getSchema(), "WrongOrders");

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestRefreshCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestRefreshCache.java
@@ -111,7 +111,7 @@ public class TestRefreshCache
                 .filter(taskInfo -> taskInfo.getCatalogSchemaTableName().equals(ordersName))
                 .findAny().orElseThrow(AssertionError::new);
 
-        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdl), orders).join();
+        TaskInfo start = cacheManager.get().createTask(new AnalyzedMDL(mdl, null), orders).join();
         assertThat(start.getTaskStatus()).isEqualTo(QUEUED);
         assertThat(start.getEndTime()).isNull();
         cacheManager.get().untilTaskDone(ordersName);

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestReloadCache.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestReloadCache.java
@@ -17,6 +17,7 @@ import io.accio.base.CatalogSchemaTableName;
 import io.accio.base.dto.Manifest;
 import io.accio.cache.TaskInfo;
 import io.accio.cache.dto.CachedTable;
+import io.accio.main.web.dto.DeployInputDto;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
@@ -118,7 +119,7 @@ public class TestReloadCache
     private void deployMDL(String resourcePath)
             throws IOException
     {
-        deployMDL(Manifest.MANIFEST_JSON_CODEC.fromJson(Files.readString(Path.of(getClass().getClassLoader().getResource(resourcePath).getPath()))));
+        deployMDL(new DeployInputDto(Manifest.MANIFEST_JSON_CODEC.fromJson(Files.readString(Path.of(getClass().getClassLoader().getResource(resourcePath).getPath()))), null));
     }
 
     private void assertCache(String name)


### PR DESCRIPTION
# Existed API Chanaged
## Deploy
Add `version` field to assign the version of MDL.
```
POST /v1/mdl/deploy
```
### Sample
```json
{
	"manifest": {
		"models": [
				{
					"name": "Orders",
					"refSql": "...",
					"columns": [ ... ],
					"properties": {}
				},
				{
					"name": "Lineitem",
					"refSql": "...",
					"columns": [ ... ]
				},
				{
					"name": "Customer",
					"refSql": "...",
					"columns": [ ... ]
				}
		],
		"relationships": [
			...
		]
	},
  "version": "xxxx"
}
```

## Status
Now, only return the version instead of full manfiest.
```
GET /v1/mdl/status
```
### Sample
```json
{
  "systemStatus": "READY",  // READY, PREPARE 
  "version": "xxx"
}
```

## Preview
Now, `manifest` is optional. Use deployed MDL when previewing if the manifest isn't carried.
```
GET /v1/mdl/preview
```

# New API
## Get Current MDL
Return the current deployed MDL.
```
GET /v1/mdl
```
### Sample
```json
{
	"models": [
		{
			"name": "Orders",
			"refSql": "...",
			"columns": [ ... ],
			"properties": {}
		},
		{
			"name": "Lineitem",
			"refSql": "...",
			"columns": [ ... ]
		},
		{
			"name": "Customer",
			"refSql": "...",
			"columns": [ ... ]
		}
		],
	"relationships": [
		...
	]
}
```
