### PR TITLE
Throw error if a specific table isn't found

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
@@ -120,6 +120,7 @@ public class AccioSqlRewrite
             descriptors.forEach(queryDescriptor -> withQueries.add(getWithQuery(queryDescriptor)));
             // If a selected table lacks any required fields, create a dummy with query for it.
             analysis.getTables().stream().filter(table -> !tableRequiredFields.containsKey(table.getSchemaTableName().getTableName()))
+                    .filter(table -> accioMDL.isObjectExist(table.getSchemaTableName().getTableName()))
                     .forEach(dummy -> withQueries.add(getWithQuery(new DummyInfo(dummy.getSchemaTableName().getTableName()))));
 
             Node rewriteWith = new WithRewriter(withQueries).process(root);

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
@@ -282,7 +282,7 @@ public class TestMetric
         assertThat(result.get(0).size()).isEqualTo(2);
         assertThat(result.size()).isEqualTo(14958);
 
-        assertThatCode(() -> query(rewrite("select 1 from testModelOnMetric", true)))
+        assertThatCode(() -> query(rewrite("select 1 from testModelOnMetric", mdl, true)))
                 .doesNotThrowAnyException();
     }
 
@@ -304,7 +304,7 @@ public class TestMetric
         assertThat(result.get(0).size()).isEqualTo(2);
         assertThat(result.size()).isEqualTo(7);
 
-        assertThatCode(() -> query(rewrite("select 1 from testMetricOnMetric", true)))
+        assertThatCode(() -> query(rewrite("select 1 from testMetricOnMetric", mdl, true)))
                 .doesNotThrowAnyException();
     }
 

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModel.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModel.java
@@ -41,6 +41,7 @@ import static io.accio.base.sqlrewrite.AccioSqlRewrite.ACCIO_SQL_REWRITE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestModel
         extends AbstractTestFramework
@@ -318,6 +319,18 @@ public class TestModel
 
         assertThatCode(() -> query(rewrite("SELECT orderkey FROM Lineitem, Orders", mdl, true)))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testSelectNotFound()
+    {
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(customer))
+                .setRelationships(List.of(ordersCustomer, ordersLineitem))
+                .build();
+        AccioMDL mdl = AccioMDL.fromManifest(manifest);
+        assertThatThrownBy(() -> query(rewrite("SELECT * FROM notfound", mdl, true)))
+                .hasMessageFindingMatch(".*notfound.*");
     }
 
     private void assertQuery(AccioMDL mdl, @Language("SQL") String accioSql, @Language("SQL") String duckDBSql)


### PR DESCRIPTION
After #451, we will create dummy CTE for required table but we should exclude the table which doesn't exist actually.