### PR TITLE
Disable Authentication if no auth file assigned

### DIFF
--- a/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresWireProtocol.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresWireProtocol.java
@@ -186,12 +186,18 @@ public class PostgresWireProtocol
 
     private void initAuthentication(Channel channel)
     {
-        Optional<String> password = wireProtocolSession.getPassword();
-        if (password.isPresent()) {
-            finishAuthentication(channel, password.get());
+        if (wireProtocolSession.isAuthenticationEnabled()) {
+            Optional<String> password = wireProtocolSession.getPassword();
+            if (password.isPresent()) {
+                finishAuthentication(channel, password.get());
+            }
+            else {
+                Messages.sendAuthenticationCleartextPassword(channel);
+            }
         }
         else {
-            Messages.sendAuthenticationCleartextPassword(channel);
+            Messages.sendAuthenticationOK(channel)
+                    .addListener(f -> sendParamsAndRdyForQuery(channel));
         }
     }
 

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/WireProtocolSession.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/WireProtocolSession.java
@@ -206,6 +206,11 @@ public class WireProtocolSession
                 .isPresent();
     }
 
+    public boolean isAuthenticationEnabled()
+    {
+        return authentication.isEnabled();
+    }
+
     public Optional<List<Column>> describePortal(String name)
     {
         Portal portal = getPortal(name);

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/auth/Authentication.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/auth/Authentication.java
@@ -17,4 +17,6 @@ package io.accio.main.wireprotocol.auth;
 public interface Authentication
 {
     boolean authenticate(String username, String password);
+
+    boolean isEnabled();
 }

--- a/accio-main/src/main/java/io/accio/main/wireprotocol/auth/FileAuthentication.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/auth/FileAuthentication.java
@@ -36,6 +36,12 @@ public class FileAuthentication
     }
 
     @Override
+    public boolean isEnabled()
+    {
+        return !accounts.isEmpty();
+    }
+
+    @Override
     public boolean authenticate(String username, String password)
     {
         if (accounts.isEmpty()) {

--- a/accio-tests/src/test/java/io/accio/testing/TestMetadataQuery.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestMetadataQuery.java
@@ -117,6 +117,18 @@ public class TestMetadataQuery
     }
 
     @Test
+    public void testAuthWithoutPassword()
+            throws Exception
+    {
+        try (TestingWireProtocolClient protocolClient = wireProtocolClient()) {
+            protocolClient.sendStartUpMessage(196608, null, "test", "canner");
+            protocolClient.assertAuthOk();
+            assertDefaultPgConfigResponse(protocolClient);
+            protocolClient.assertReadyForQuery('I');
+        }
+    }
+
+    @Test
     public void testExecuteAndDescribeLevel1Query()
             throws Exception
     {


### PR DESCRIPTION
If user doesn't assign any authentication file, don't send the password message to client.