### PR TITLE
Support psycopg2 via ignoring session properties

### DIFF
--- a/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresSessionProperties.java
+++ b/accio-main/src/main/java/io/accio/main/wireprotocol/PostgresSessionProperties.java
@@ -339,6 +339,7 @@ public final class PostgresSessionProperties
             "xmloption",
             "gin_pending_list_limit",
             /* Client Connection Defaults / Locale and Formatting */
+            DATE_STYLE,
             INTERVALSTYLE,
             TIMEZONE,
             "timezone_abbreviations",


### PR DESCRIPTION
## Description
`psycopg2` will send set-statement with `datestyle`.
We need to ignore the property.

## Related issues
#461