### PR TITLE
Analyze the limit and ordering for SQL analysis API

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
@@ -27,6 +27,7 @@ import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionRelation;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.Table;
 
@@ -36,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -59,6 +61,8 @@ public class Analysis
     private final List<SimplePredicate> simplePredicates = new ArrayList<>();
 
     private final Map<NodeRef<Node>, Node> typeCoercionMap = new HashMap<>();
+    private Expression limit;
+    private final List<SortItemAnalysis> sortItems = new ArrayList<>();
 
     public Analysis(Statement statement)
     {
@@ -185,6 +189,26 @@ public class Analysis
         return typeCoercionMap;
     }
 
+    public Optional<Expression> getLimit()
+    {
+        return Optional.ofNullable(limit);
+    }
+
+    public void setLimit(Expression limit)
+    {
+        this.limit = limit;
+    }
+
+    public List<SortItemAnalysis> getSortItems()
+    {
+        return sortItems;
+    }
+
+    public void addSortItem(SortItemAnalysis sortItem)
+    {
+        sortItems.add(sortItem);
+    }
+
     /**
      * A placeholder to record predicates like c1 = 'foo', c2 >= 1
      */
@@ -257,6 +281,57 @@ public class Analysis
                     .add("columnName", columnName)
                     .add("operator", operator)
                     .add("value", value)
+                    .toString();
+        }
+    }
+
+    public static class SortItemAnalysis
+    {
+        private QualifiedName sortKey;
+        private String ordering;
+
+        public SortItemAnalysis(QualifiedName sortKey, String ordering)
+        {
+            this.sortKey = sortKey;
+            this.ordering = ordering;
+        }
+
+        public QualifiedName getSortKey()
+        {
+            return sortKey;
+        }
+
+        public String getOrdering()
+        {
+            return ordering;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SortItemAnalysis that = (SortItemAnalysis) o;
+            return Objects.equals(sortKey, that.sortKey) &&
+                    Objects.equals(ordering, that.ordering);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(sortKey, ordering);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("sortKey", sortKey)
+                    .add("ordering", ordering)
                     .toString();
         }
     }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
@@ -248,7 +248,9 @@ public class TestStatementAnalyzer
                         model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2")))))
                 .build();
 
-        assertThat(analyzeSql("SELECT * FROM table_1 LIMIT 100", manifest).getLimit()).isEqualTo(new LongLiteral("100"));
+        assertThat(analyzeSql("SELECT * FROM table_1 LIMIT 100", manifest).getLimit()).isEqualTo(Optional.of(new LongLiteral("100")));
+        assertThat(analyzeSql("SELECT * FROM table_1", manifest).getLimit()).isEqualTo(Optional.empty());
+        assertThat(analyzeSql("SELECT * FROM table_1 LIMIT 100::integer", manifest).getLimit()).isEqualTo(Optional.of(new LongLiteral("100")));
     }
 
     @Test

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
@@ -30,6 +30,7 @@ import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
@@ -234,6 +235,64 @@ public class TestStatementAnalyzer
         assertThat(scope.get().getRelationType().getFields()).hasSize(2);
         assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");
         assertThat(scope.get().getRelationType().getFields().get(1).getName().get()).isEqualTo("max_c2");
+    }
+
+    @Test
+    public void testAnalyzeLimit()
+    {
+        Manifest manifest = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("test")
+                .setModels(ImmutableList.of(
+                        model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2"))),
+                        model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2")))))
+                .build();
+
+        assertThat(analyzeSql("SELECT * FROM table_1 LIMIT 100", manifest).getLimit()).isEqualTo(new LongLiteral("100"));
+    }
+
+    @Test
+    public void testAnalyzeOrderBy()
+    {
+        Manifest manifest = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("test")
+                .setModels(ImmutableList.of(
+                        model("table_1", "SELECT * FROM foo", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2"))),
+                        model("table_2", "SELECT * FROM bar", ImmutableList.of(varcharColumn("c1"), varcharColumn("c2")))))
+                .build();
+
+        assertThat(analyzeSql("SELECT * FROM table_1 ORDER BY c1, c2", manifest).getSortItems())
+                .isEqualTo(List.of(ascSortItem(QualifiedName.of("c1")), ascSortItem(QualifiedName.of("c2"))));
+        assertThat(analyzeSql("SELECT * FROM table_1 ORDER BY c1 desc, c2 asc", manifest).getSortItems())
+                .isEqualTo(List.of(descSortItem(QualifiedName.of("c1")), ascSortItem(QualifiedName.of("c2"))));
+
+        assertThat(analyzeSql("SELECT * FROM table_1 ORDER BY 1, 2", manifest).getSortItems())
+                .isEqualTo(List.of(ascSortItem(QualifiedName.of("table_1", "c1")), ascSortItem(QualifiedName.of("table_1", "c2"))));
+
+        assertThat(analyzeSql("SELECT * FROM table_1, table_2 ORDER BY 1, 2, 3, 4", manifest).getSortItems())
+                .isEqualTo(List.of(
+                        ascSortItem(QualifiedName.of("table_1", "c1")),
+                        ascSortItem(QualifiedName.of("table_1", "c2")),
+                        ascSortItem(QualifiedName.of("table_2", "c1")),
+                        ascSortItem(QualifiedName.of("table_2", "c2"))));
+
+        assertThat(analyzeSql("SELECT * FROM table_1, table_2 ORDER BY table_1.c1, 2, 4, table_2.c1", manifest).getSortItems())
+                .isEqualTo(List.of(
+                        ascSortItem(QualifiedName.of("table_1", "c1")),
+                        ascSortItem(QualifiedName.of("table_1", "c2")),
+                        ascSortItem(QualifiedName.of("table_2", "c2")),
+                        ascSortItem(QualifiedName.of("table_2", "c1"))));
+    }
+
+    private static Analysis.SortItemAnalysis ascSortItem(QualifiedName sortKey)
+    {
+        return new Analysis.SortItemAnalysis(sortKey, SortItem.Ordering.ASCENDING.name());
+    }
+
+    private static Analysis.SortItemAnalysis descSortItem(QualifiedName sortKey)
+    {
+        return new Analysis.SortItemAnalysis(sortKey, SortItem.Ordering.DESCENDING.name());
     }
 
     private static Column varcharColumn(String name)

--- a/accio-main/src/main/java/io/accio/main/web/dto/SqlAnalysisOutputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/SqlAnalysisOutputDto.java
@@ -27,14 +27,20 @@ public class SqlAnalysisOutputDto
 {
     private final String modelName;
     private final List<ColumnPredicateDto> columnPredicates;
+    private final String limit;
+    private final List<SortItem> ordering;
 
     @JsonCreator
     public SqlAnalysisOutputDto(
             @JsonProperty("modelName") String modelName,
-            @JsonProperty("columnPredicates") List<ColumnPredicateDto> columnPredicates)
+            @JsonProperty("columnPredicates") List<ColumnPredicateDto> columnPredicates,
+            @JsonProperty("limit") String limit,
+            @JsonProperty("ordering") List<SortItem> ordering)
     {
         this.modelName = requireNonNull(modelName);
-        this.columnPredicates = requireNonNull(columnPredicates);
+        this.columnPredicates = columnPredicates;
+        this.limit = limit;
+        this.ordering = ordering == null ? List.of() : ordering;
     }
 
     @JsonProperty
@@ -49,6 +55,18 @@ public class SqlAnalysisOutputDto
         return columnPredicates;
     }
 
+    @JsonProperty
+    public String getLimit()
+    {
+        return limit;
+    }
+
+    @JsonProperty
+    public List<SortItem> getOrdering()
+    {
+        return ordering;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -59,13 +77,20 @@ public class SqlAnalysisOutputDto
             return false;
         }
         SqlAnalysisOutputDto that = (SqlAnalysisOutputDto) o;
-        return Objects.equals(modelName, that.modelName) && Objects.equals(columnPredicates, that.columnPredicates);
+        return Objects.equals(modelName, that.modelName) &&
+                Objects.equals(columnPredicates, that.columnPredicates)
+                && Objects.equals(limit, that.limit)
+                && Objects.equals(ordering, that.ordering);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(modelName, columnPredicates);
+        return Objects.hash(
+                modelName,
+                columnPredicates,
+                limit,
+                ordering);
     }
 
     @Override
@@ -75,5 +100,64 @@ public class SqlAnalysisOutputDto
                 .add("modelName", modelName)
                 .add("columnPredicates", columnPredicates)
                 .toString();
+    }
+
+    public static class SortItem
+    {
+        private final String identifier;
+        private final String direction;
+
+        @JsonCreator
+        public SortItem(
+                @JsonProperty("identifier") String identifier,
+                @JsonProperty("direction") String direction)
+        {
+            this.identifier = identifier;
+            this.direction = direction;
+        }
+
+        @JsonProperty
+        public String getIdentifier()
+        {
+            return identifier;
+        }
+
+        @JsonProperty
+        public String getDirection()
+        {
+            return direction;
+        }
+
+        // generate to string function
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("identifier", identifier)
+                    .add("direction", direction)
+                    .toString();
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            SortItem sortItem = (SortItem) o;
+            return Objects.equals(identifier, sortItem.identifier) &&
+                    Objects.equals(direction, sortItem.direction);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(identifier, direction);
+        }
     }
 }


### PR DESCRIPTION
# Description
Enhance the SQL analysis API for analyzing `LIMIT` and `ORDER BY` part.
```
GET /v1/analysis/sql
```

# Sample Input and Output
## input
```json
{
    "sql": "SELECT * FROM Model_Customer WHERE customer_id = 1 order by customer_id desc limit 100"   
}
```
## output
```json
[
    {
        "columnPredicates": [
            {
                "columnName": "customer_id",
                "predicates": [
                    {
                        "operator": "=",
                        "value": "1"
                    }
                ]
            }
        ],
        "limit": "100",
        "modelName": "Model_Customer",
        "ordering": [
            {
                "direction": "DESCENDING",
                "identifier": "customer_id"
            }
        ]
    }
]
```