### PR TITLE
Enhance the scope analysis in StatementAnalyzer

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/RelationId.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/RelationId.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.accio.base.sqlrewrite.analyzer;
+
+import io.trino.sql.tree.Node;
+import io.trino.sql.tree.NodeRef;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.String.format;
+import static java.lang.System.identityHashCode;
+
+public class RelationId
+{
+    /**
+     * Creates {@link RelationId} equal to any {@link RelationId} created from exactly the same source.
+     */
+    public static RelationId of(Node sourceNode)
+    {
+        return new RelationId(Optional.of(NodeRef.of(sourceNode)));
+    }
+
+    /**
+     * Creates {@link RelationId} equal only to itself
+     */
+    public static RelationId anonymous()
+    {
+        return new RelationId(Optional.empty());
+    }
+
+    private final Optional<NodeRef<Node>> sourceNode;
+
+    private RelationId(Optional<NodeRef<Node>> sourceNode)
+    {
+        this.sourceNode = sourceNode;
+    }
+
+    public boolean isAnonymous()
+    {
+        return sourceNode.isEmpty();
+    }
+
+    public Optional<Node> getSourceNode()
+    {
+        return sourceNode.map(NodeRef::getNode);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RelationId that = (RelationId) o;
+        return sourceNode.isPresent() && that.sourceNode.isPresent() && sourceNode.equals(that.sourceNode);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sourceNode);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (isAnonymous()) {
+            return toStringHelper(this)
+                    .addValue("anonymous")
+                    .addValue(format("x%08x", identityHashCode(this)))
+                    .toString();
+        }
+        else {
+            return toStringHelper(this)
+                    .addValue(sourceNode.get().getClass().getSimpleName())
+                    .addValue(format("x%08x", identityHashCode(sourceNode.get())))
+                    .toString();
+        }
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Scope.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Scope.java
@@ -26,13 +26,20 @@ import static java.util.Objects.requireNonNull;
 public class Scope
 {
     private final Optional<Scope> parent;
+    private final RelationId relationId;
     private final RelationType relationType;
     private final boolean isDataSourceScope;
     private final Map<String, WithQuery> namedQueries;
 
-    private Scope(Scope parent, RelationType relationType, boolean isDataSourceScope, Map<String, WithQuery> namedQueries)
+    private Scope(
+            Scope parent,
+            RelationId relationId,
+            RelationType relationType,
+            boolean isDataSourceScope,
+            Map<String, WithQuery> namedQueries)
     {
         this.parent = Optional.ofNullable(parent);
+        this.relationId = requireNonNull(relationId, "relationId is null");
         this.relationType = requireNonNull(relationType, "relationType is null");
         this.isDataSourceScope = isDataSourceScope;
         this.namedQueries = requireNonNull(namedQueries, "namedQueries is null");
@@ -46,6 +53,11 @@ public class Scope
     public RelationType getRelationType()
     {
         return relationType;
+    }
+
+    public RelationId getRelationId()
+    {
+        return relationId;
     }
 
     public boolean isDataSourceScope()
@@ -74,6 +86,7 @@ public class Scope
     public static final class Builder
     {
         private Optional<Scope> parent = Optional.empty();
+        private RelationId relationId = RelationId.anonymous();
         private RelationType relationType = new RelationType();
         private boolean isDataSourceScope;
         private final Map<String, WithQuery> namedQueries = new HashMap<>();
@@ -81,6 +94,12 @@ public class Scope
         public Builder relationType(RelationType relationType)
         {
             this.relationType = relationType;
+            return this;
+        }
+
+        public Builder relationId(RelationId relationId)
+        {
+            this.relationId = relationId;
             return this;
         }
 
@@ -111,7 +130,7 @@ public class Scope
 
         public Scope build()
         {
-            return new Scope(parent.orElse(null), relationType, isDataSourceScope, namedQueries);
+            return new Scope(parent.orElse(null), relationId, relationType, isDataSourceScope, namedQueries);
         }
     }
 }


### PR DESCRIPTION
# Description
To support the more complex SQL analysis, we should enhance the SQL analysis firstly.
# Changed
- Collect all scope info for each node to a map. It's useful for generating the rewrite plan in the future.
- Assign the relation Id for every scope.