### PR TITLE
Fix the accessing behavior for metric or model in the dynamic access mode

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/Analysis.java
@@ -29,7 +29,6 @@ import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Statement;
-import io.trino.sql.tree.Table;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,7 +52,6 @@ public class Analysis
     private final Map<NodeRef<Node>, Scope> scopes = new LinkedHashMap<>();
 
     private final Set<CatalogSchemaTableName> tables = new HashSet<>();
-    private final Set<NodeRef<Table>> modelNodeRefs = new HashSet<>();
     private final Set<Relationship> relationships = new HashSet<>();
     private final Set<Model> models = new HashSet<>();
     private final Set<Metric> metrics = new HashSet<>();
@@ -64,6 +62,9 @@ public class Analysis
     private final Multimap<CatalogSchemaTableName, String> collectedColumns = HashMultimap.create();
     private final List<SimplePredicate> simplePredicates = new ArrayList<>();
 
+    private final Set<Node> requiredSourceNodes = new HashSet<>();
+
+    private final Map<NodeRef<Node>, QualifiedName> sourceNodeNames = new HashMap<>();
     private final Map<NodeRef<Node>, Node> typeCoercionMap = new HashMap<>();
     private Expression limit;
     private final List<SortItemAnalysis> sortItems = new ArrayList<>();
@@ -101,16 +102,6 @@ public class Analysis
     public Set<Model> getModels()
     {
         return models;
-    }
-
-    void addModelNodeRef(NodeRef<Table> tableNodeRef)
-    {
-        this.modelNodeRefs.add(tableNodeRef);
-    }
-
-    public Set<NodeRef<Table>> getModelNodeRefs()
-    {
-        return modelNodeRefs;
     }
 
     void addMetrics(Set<Metric> metrics)
@@ -236,6 +227,31 @@ public class Analysis
     public void setScope(Node node, Scope scope)
     {
         scopes.put(NodeRef.of(node), scope);
+    }
+
+    public Map<NodeRef<Node>, Scope> getScopes()
+    {
+        return scopes;
+    }
+
+    public Set<Node> getRequiredSourceNodes()
+    {
+        return requiredSourceNodes;
+    }
+
+    public void addRequiredSourceNode(Node node)
+    {
+        requiredSourceNodes.add(node);
+    }
+
+    public Optional<QualifiedName> getSourceNodeNames(Node node)
+    {
+        return Optional.ofNullable(sourceNodeNames.get(NodeRef.of(node)));
+    }
+
+    public void addSourceNodeName(NodeRef<Node> nodeRef, QualifiedName name)
+    {
+        sourceNodeNames.put(nodeRef, name);
     }
 
     /**

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalysis.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalysis.java
@@ -29,12 +29,15 @@ public class ExpressionAnalysis
     private final List<Field> collectedFields;
     private final Map<NodeRef<Expression>, Field> referencedFields;
     private final List<ComparisonExpression> predicates;
+    // For `count(*)` expression, we should generate the specific CTE for it.
+    private final boolean requireRelation;
 
-    public ExpressionAnalysis(Map<NodeRef<Expression>, Field> referenceFields, List<ComparisonExpression> predicates)
+    public ExpressionAnalysis(Map<NodeRef<Expression>, Field> referenceFields, List<ComparisonExpression> predicates, boolean requireRelation)
     {
         this.referencedFields = requireNonNull(referenceFields);
         this.collectedFields = referenceFields.values().stream().collect(toImmutableList());
         this.predicates = requireNonNull(predicates);
+        this.requireRelation = requireRelation;
     }
 
     public List<Field> getCollectedFields()
@@ -50,5 +53,10 @@ public class ExpressionAnalysis
     public List<ComparisonExpression> getPredicates()
     {
         return predicates;
+    }
+
+    public boolean isRequireRelation()
+    {
+        return requireRelation;
     }
 }

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
@@ -95,7 +95,9 @@ public class ExpressionAnalyzer
         {
             if (node.getName().getSuffix().equalsIgnoreCase("count") && node.getArguments().isEmpty()) {
                 requireRelation = true;
+                return null;
             }
+            node.getArguments().forEach(this::process);
             return null;
         }
 

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
@@ -19,6 +19,7 @@ import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.DefaultTraversalVisitor;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.QualifiedName;
@@ -40,7 +41,7 @@ public class ExpressionAnalyzer
         ExpressionVisitor visitor = new ExpressionVisitor(scope);
         visitor.process(expression);
 
-        return new ExpressionAnalysis(visitor.getReferenceFields(), visitor.getPredicates());
+        return new ExpressionAnalysis(visitor.getReferenceFields(), visitor.getPredicates(), visitor.isRequireRelation());
     }
 
     private static class ExpressionVisitor
@@ -49,6 +50,7 @@ public class ExpressionAnalyzer
         private final Scope scope;
         private final Map<NodeRef<Expression>, Field> referenceFields = new HashMap<>();
         private final List<ComparisonExpression> predicates = new ArrayList<>();
+        private boolean requireRelation;
 
         public ExpressionVisitor(Scope scope)
         {
@@ -88,6 +90,15 @@ public class ExpressionAnalyzer
             return null;
         }
 
+        @Override
+        protected Void visitFunctionCall(FunctionCall node, Void context)
+        {
+            if (node.getName().getSuffix().equalsIgnoreCase("count") && node.getArguments().isEmpty()) {
+                requireRelation = true;
+            }
+            return null;
+        }
+
         public Map<NodeRef<Expression>, Field> getReferenceFields()
         {
             return referenceFields;
@@ -96,6 +107,11 @@ public class ExpressionAnalyzer
         public List<ComparisonExpression> getPredicates()
         {
             return predicates;
+        }
+
+        public boolean isRequireRelation()
+        {
+            return requireRelation;
         }
     }
 }

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
@@ -336,6 +336,14 @@ public class TestMetric
         // select dim custkey and measure count in CountOrders
         assertThat(query(rewrite("SELECT custkey, count FROM CountOrders WHERE custkey = 370", true)))
                 .isEqualTo(query("SELECT custkey, count(*) FROM orders WHERE custkey = 370 GROUP BY 1"));
+
+        // select only measure will use all dimension
+        assertThat(query(rewrite("SELECT count FROM CountOrders ORDER BY 1", true)))
+                .isEqualTo(query("WITH output AS (SELECT count(*) AS count FROM orders) SELECT count FROM output ORDER BY 1"));
+
+        // apply count(*) on metric
+        assertThat(query(rewrite("SELECT count(*) FROM CountOrders ORDER BY 1", true)))
+                .isEqualTo(query("WITH output AS (SELECT custkey, orderstatus, count(*) AS count FROM orders GROUP BY 1, 2) SELECT count(*) FROM output"));
     }
 
     @Test

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
@@ -344,6 +344,10 @@ public class TestMetric
         // apply count(*) on metric
         assertThat(query(rewrite("SELECT count(*) FROM CountOrders ORDER BY 1", true)))
                 .isEqualTo(query("WITH output AS (SELECT custkey, orderstatus, count(*) AS count FROM orders GROUP BY 1, 2) SELECT count(*) FROM output"));
+
+        // apply count(custkey) on metric
+        assertThat(query(rewrite("SELECT count(custkey) FROM CountOrders ORDER BY 1", true)))
+                .isEqualTo(query("WITH output AS (SELECT custkey, count(*) FROM orders GROUP BY 1) SELECT count(custkey) FROM output"));
     }
 
     @Test

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModel.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModel.java
@@ -198,6 +198,8 @@ public class TestModel
                         "LEFT JOIN orders o ON l.orderkey = o.orderkey\n" +
                         "LEFT JOIN customer c ON o.custkey = c.custkey\n" +
                         "WHERE l.orderkey = 44995");
+
+        assertQuery(mdl, "SELECT count(*) FROM Lineitem", "SELECT count(*) FROM lineitem");
     }
 
     @Test


### PR DESCRIPTION
# Description
Redefine the access behavior of dynamic metric accessing. Given a sample manifest:
```JSON
    {
      "name": "Revenue",
      "baseObject": "Orders",
      "dimension": [
        {
          "name": "custkey",
          "type": "integer"
        },
        {
          "name": "orderdate",
          "type": "date"
        }
      ],
      "measure": [
        {
          "name": "totalprice",
          "type": "integer",
          "expression": "sum(totalprice)"
        }
      ],
      "timeGrain": [
        {
          "name": "orderdate",
          "refColumn": "orderdate",
          "dateParts": [
            "YEAR",
            "MONTH"
          ]
        }
      ]
    }
```
Some behaviors were changed.

## SELECT only measure
```SQL
SELECT totalprice FROM Revenue
```
### Generated SQL
```SQL
WITH Revenue AS (
	SELECT 
		sum(totalprice) as totalprice
	FROM Orders
)
SELECT totalprice FROM Revenue
```

## Apply aggregation without any specific column
```sql
SELECT count(*) FROM Revenue
```

### Generated SQL
```SQL
WITH Revenue AS (
	SELECT
		custkey,
		orderdate,
		sum(totalprice) as totalprice
	FROM Orders
	GROUP BY 1, 2
)
SELECT count(*) FROM Revenue
```

## Apply aggregation with the specific column
```sql
SELECT count(custkey) FROM Revenue
```
### Generated SQL
```SQL
WITH Revenue AS (
	SELECT
		custkey,
		count(*)
	FROM Orders
	GROUP BY 1
)
SELECT count(custkey) FROM Revenue
```