### PR TITLE
Upgrade azul/zulu-openjdk from 11.0.14 to 11.0.22 for arm64

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:11.0.14
+FROM azul/zulu-openjdk:11.0.22
 LABEL maintainer="https://www.canner.io/"
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
azul/zulu-openjdk:11.0.14 only has amd64, but 11.0.22 has `arm64`.