### PR TITLE
Fix for PostgreSQL as data source

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioSqlRewrite.java
@@ -16,6 +16,7 @@ package io.accio.base.sqlrewrite;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import io.accio.base.AccioMDL;
 import io.accio.base.AnalyzedMDL;
 import io.accio.base.CatalogSchemaTableName;
@@ -294,7 +295,7 @@ public class AccioSqlRewrite
         // the model is added in with query, and the catalog and schema should be removed
         private Node applyModelRule(Table table)
         {
-            return new Table(QualifiedName.of(table.getName().getSuffix()));
+            return new Table(QualifiedName.of(ImmutableList.of(Iterables.getLast(table.getName().getOriginalParts()))));
         }
     }
 

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetricViewSqlRewrite.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetricViewSqlRewrite.java
@@ -179,7 +179,7 @@ public class TestMetricViewSqlRewrite
                                 "   , \"name\" \"album_name\"\n" +
                                 "   , sum(price) \"price\"\n" +
                                 "   FROM\n" +
-                                "     Album\n" +
+                                "     \"Album\"\n" +
                                 "   GROUP BY 1, 2, 3\n" +
                                 ")  Collection"
                 },
@@ -198,7 +198,7 @@ public class TestMetricViewSqlRewrite
                                 "   , \"name\" \"album_name\"\n" +
                                 "   , sum(price) \"price\"\n" +
                                 "   FROM\n" +
-                                "     Album\n" +
+                                "     \"Album\"\n" +
                                 "   GROUP BY 1, 2, 3\n" +
                                 ")  Collection"
                 },

--- a/accio-server/src/main/java/io/accio/server/module/PostgresConnectorModule.java
+++ b/accio-server/src/main/java/io/accio/server/module/PostgresConnectorModule.java
@@ -20,6 +20,7 @@ import io.accio.base.sql.SqlConverter;
 import io.accio.cache.CacheService;
 import io.accio.connector.postgres.PostgresClient;
 import io.accio.connector.postgres.PostgresConfig;
+import io.accio.main.connector.duckdb.DuckDBMetadata;
 import io.accio.main.connector.postgres.PostgresCacheService;
 import io.accio.main.connector.postgres.PostgresMetadata;
 import io.accio.main.connector.postgres.PostgresSqlConverter;
@@ -51,7 +52,7 @@ public class PostgresConnectorModule
         binder.bind(PgMetadata.class).to(PostgresPgMetadata.class).in(Scopes.SINGLETON);
         binder.bind(CacheService.class).to(PostgresCacheService.class).in(Scopes.SINGLETON);
         binder.bind(PgMetastoreFunctionBuilder.class).to(DuckDBFunctionBuilder.class).in(Scopes.SINGLETON);
-        binder.bind(PgMetastore.class).to(PostgresMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(PgMetastore.class).to(DuckDBMetadata.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(PostgresConfig.class);
     }


### PR DESCRIPTION
We tried to make PostgreSQL as data source and use Metabase to connect Accio. We found some issues.

PgMetastore should bind DuckDBMetadata not PostgresMetadata. Although the Data source is PostgreSQL, the metastore still uses DuckDB in our design.

Metabase will send a statement like `select * from "orders"` to Accio. But Accio remove the quoted when the rewriter rewrite. We should not change the quoted delimited status.